### PR TITLE
Return 503 code from status until initial registration is complete

### DIFF
--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/DeviceServer.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/DeviceServer.kt
@@ -132,7 +132,8 @@ fun Application.module() {
             call.respond(statusController.welcomeMessage(routes))
         }
         get("status") {
-            call.respond(statusController.getServerStatus())
+            val code = if (deviceManager.isReady()) HttpStatusCode.OK else HttpStatusCode.ServiceUnavailable
+            call.respond(code, statusController.getServerStatus())
         }
         route("devices") {
             get {

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/management/DeviceManager.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/management/DeviceManager.kt
@@ -131,4 +131,8 @@ class DeviceManager(
         val devices = nodeRegistry.activeDevices.getUserDeviceRefs(userId)
         nodeRegistry.activeDevices.releaseDevices(devices, reason)
     }
+
+    override fun isReady(): Boolean {
+        return nodeRegistry.getInitialRegistrationComplete()
+    }
 }

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/management/IDeviceManager.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/management/IDeviceManager.kt
@@ -23,4 +23,5 @@ interface IDeviceManager {
     fun readyForRelease(): List<DeviceRef>
     fun getStatus(): Map<String, Any>
     fun releaseUserDevices(userId: String, reason: String)
+    fun isReady(): Boolean
 }


### PR DESCRIPTION
Device Server cannot create devices until initial registration of nodes is complete. Return 503 from /status endpoint until completed, return 200 after.