### PR TITLE
Make error messages more informative

### DIFF
--- a/device-server/build.gradle
+++ b/device-server/build.gradle
@@ -119,7 +119,7 @@ run {
     systemProperty 'wda.bundle.path', '../ios/facebook/simulators/WebDriverAgentRunner-Runner.app'
     systemProperty 'wda.device.bundle.path', '../ios/facebook/devices/WebDriverAgentRunner-Runner.app'
     systemProperty 'device.server.config.path', ''
-    systemProperty 'logback.configurationFile', 'logback.xml'
+    systemProperty 'logback.configurationFile', 'logback-test.xml'
 }
 
 test {

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/DeviceServer.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/DeviceServer.kt
@@ -7,6 +7,7 @@ import com.badoo.automation.deviceserver.data.DesiredCapabilities
 import com.badoo.automation.deviceserver.data.ErrorDto
 import com.badoo.automation.deviceserver.data.toDto
 import com.badoo.automation.deviceserver.host.management.DeviceManager
+import com.badoo.automation.deviceserver.host.management.errors.DeviceCreationException
 import com.badoo.automation.deviceserver.host.management.errors.DeviceNotFoundException
 import com.badoo.automation.deviceserver.host.management.errors.NoAliveNodesException
 import com.badoo.automation.deviceserver.host.management.errors.OverCapacityException
@@ -228,8 +229,11 @@ fun Application.module() {
                 is DeviceNotFoundException -> HttpStatusCode.NotFound
                 is NoAliveNodesException -> HttpStatusCode.TooManyRequests
                 is OverCapacityException -> HttpStatusCode.TooManyRequests
+                is DeviceCreationException -> HttpStatusCode.ServiceUnavailable
                 else -> HttpStatusCode.InternalServerError
             }
+
+            logger.error(call.request.toString(), exception)
             call.respond(statusCode,
                     hashMapOf(
                             "error" to exception.toDto()

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/management/ISimulatorHostChecker.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/management/ISimulatorHostChecker.kt
@@ -51,7 +51,7 @@ class SimulatorHostChecker(
         val xcodeVersion = XcodeVersion.fromXcodeBuildOutput(xcodeOutput.stdOut)
 
         if (xcodeVersion < XcodeVersion(9, 0)) {
-            throw RuntimeException("Expecting Xcode 9 or higher, but received $xcodeOutput")
+            throw RuntimeException("Expecting Xcode 9 or higher, but received $xcodeVersion. $xcodeOutput")
         }
 
         // temp solution, prereq should be satisfied without having to switch anything

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/management/NodeRegistrar.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/management/NodeRegistrar.kt
@@ -18,7 +18,7 @@ class NodeRegistrar(
 
     private val logger = LoggerFactory.getLogger(javaClass.simpleName)
     private var autoRegisteringJob: Future<*>? = null
-    private val nodeWrappers: List<NodeWrapper> = nodesConfig.map {
+    val nodeWrappers: List<NodeWrapper> = nodesConfig.map {
         NodeWrapper(it, nodeFactory, nodeRegistry)
     }
 

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/management/NodeRegistry.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/management/NodeRegistry.kt
@@ -5,6 +5,7 @@ import com.badoo.automation.deviceserver.data.DesiredCapabilities
 import com.badoo.automation.deviceserver.data.DeviceDTO
 import com.badoo.automation.deviceserver.host.ISimulatorsNode
 import com.badoo.automation.deviceserver.host.management.errors.NoAliveNodesException
+import com.badoo.automation.deviceserver.host.management.errors.NoNodesRegisteredException
 import com.badoo.automation.deviceserver.ios.ActiveDevices
 import com.badoo.automation.deviceserver.ios.simulator.simulatorsThreadPool
 import kotlinx.coroutines.experimental.Job
@@ -46,7 +47,7 @@ class NodeRegistry(val activeDevices: ActiveDevices = ActiveDevices()) {
         return nodeWrappers
     }
 
-    fun getAlive(): Set<NodeWrapper> {
+    private fun getAlive(): Set<NodeWrapper> {
         return nodeWrappers.filter { it.isAlive() }.toSet()
     }
 
@@ -59,6 +60,10 @@ class NodeRegistry(val activeDevices: ActiveDevices = ActiveDevices()) {
     }
 
     fun createDeviceAsync(desiredCapabilities: DesiredCapabilities, deviceTimeout: Duration, userId: String?): DeviceDTO {
+        if (getAll().isEmpty()) {
+            throw NoNodesRegisteredException("No nodes are registered to create a device")
+        }
+
         val node: ISimulatorsNode = getAlive()
                 .map { wrapper -> wrapper.node }
                 .maxBy { node -> node.capacityRemaining(desiredCapabilities) }

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/management/NodeWrapper.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/management/NodeWrapper.kt
@@ -32,6 +32,8 @@ class NodeWrapper(
     private var healthCheckPeriodicTask: Future<*>? = null
     val node: ISimulatorsNode = hostFactory.getHostFromConfig(config)
 
+    var lastError: Exception? = null
+
     fun isAlive(): Boolean = isStarted && node.isReachable()
 
     override fun toString(): String = "NodeWrapper for ${config.host}"
@@ -53,8 +55,10 @@ class NodeWrapper(
                 node.prepareNode()
                 logger.info(logMarker, "Successfully started the node from config: $config")
                 isStarted = true
+                lastError = null
             } catch (e: Exception) {
                 logger.error(logMarker, "Failed to start the node from config: $config", e)
+                lastError = e
             }
             return isStarted
         }

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/management/RuntimeVersion.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/management/RuntimeVersion.kt
@@ -8,7 +8,13 @@ class RuntimeVersion(runtime: String) {
         private set
 
     init {
-        val (a, b) = runtime.split(' ', ignoreCase = false, limit = 2)
+        val parts = runtime.split(' ', ignoreCase = false, limit = 2)
+
+        if (parts.size < 2) {
+            throw IllegalArgumentException("Invalid runtime '$runtime' requested. Runtime is expected to contain name and version specifier separated by space, for example, 'iOS 11'.")
+        }
+
+        val (a, b) = parts
         name = a
         fragments = b.split('.').toList()
     }

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/management/XcodeVersion.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/management/XcodeVersion.kt
@@ -1,6 +1,6 @@
-package com.badoo.automation.deviceserver.host.management;
+package com.badoo.automation.deviceserver.host.management
 
-class XcodeVersion(val major: Int, val minor: Int):Comparable<XcodeVersion> {
+data class XcodeVersion(val major: Int, val minor: Int):Comparable<XcodeVersion> {
     companion object {
         fun fromXcodeBuildOutput(output: String): XcodeVersion {
             val regex = Regex("Xcode (\\d+)\\.(\\d+)(\\.(\\d+))?")
@@ -30,5 +30,9 @@ class XcodeVersion(val major: Int, val minor: Int):Comparable<XcodeVersion> {
 
     override operator fun compareTo(other: XcodeVersion): Int {
         return COMPARATOR.compare(this, other)
+    }
+
+    override fun toString(): String {
+        return "$major.$minor"
     }
 }

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/management/errors/DeviceCreationException.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/management/errors/DeviceCreationException.kt
@@ -1,0 +1,3 @@
+package com.badoo.automation.deviceserver.host.management.errors
+
+open class DeviceCreationException(message: String): RuntimeException(message)

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/management/errors/NoAliveNodesException.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/management/errors/NoAliveNodesException.kt
@@ -1,3 +1,3 @@
 package com.badoo.automation.deviceserver.host.management.errors
 
-class NoAliveNodesException(message: String): RuntimeException(message)
+class NoAliveNodesException(message: String): DeviceCreationException(message)

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/management/errors/NoNodesRegisteredException.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/management/errors/NoNodesRegisteredException.kt
@@ -1,0 +1,3 @@
+package com.badoo.automation.deviceserver.host.management.errors
+
+class NoNodesRegisteredException(message: String): DeviceCreationException(message)

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/fbsimctl/SimulatorTypes.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/fbsimctl/SimulatorTypes.kt
@@ -1,0 +1,26 @@
+package com.badoo.automation.deviceserver.ios.fbsimctl
+
+import com.badoo.automation.deviceserver.JsonMapper
+import com.badoo.automation.deviceserver.command.IShellCommand
+
+class SimulatorTypes(private val shellCommand: IShellCommand) {
+    private val mapper = JsonMapper()
+
+    fun availableRuntimes(): List<String> {
+        return fetch("runtimes")
+    }
+
+    fun availableModels(): List<String> {
+        return fetch("devicetypes")
+    }
+
+    private fun fetch(type: String): List<String> {
+        val rv = shellCommand.exec(listOf("xcrun", "simctl", "list", "--json", type))
+
+        if (!rv.isSuccess) {
+            return emptyList()
+        }
+
+        return mapper.readTree(rv.stdOut.byteInputStream())[type].mapNotNull { it["name"].toString() }.toList()
+    }
+}

--- a/device-server/src/main/resources/logback-test.xml
+++ b/device-server/src/main/resources/logback-test.xml
@@ -2,7 +2,13 @@
     <conversionRule conversionWord="highlight" converterClass="deviceserver.LogHighlighter" />
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{YYYY-MM-dd HH:mm:ss.SSS} [%thread] %highlight(%-5level) %logger{36} - %msg%n</pattern>
+            <pattern>
+                %d{YYYY-MM-dd HH:mm:ss.SSS} [%thread] %highlight(%-5level) %logger{36} - %msg%n%rEx{full,
+                    kotlinx,
+                    io.ktor,
+                    io.netty
+                }
+            </pattern>
         </encoder>
     </appender>
 

--- a/device-server/src/test/kotlin/com/badoo/automation/deviceserver/host/management/RuntimeVersionTest.kt
+++ b/device-server/src/test/kotlin/com/badoo/automation/deviceserver/host/management/RuntimeVersionTest.kt
@@ -1,0 +1,27 @@
+package com.badoo.automation.deviceserver.host.management
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class RuntimeVersionTest {
+    @Test
+    fun shouldParseValidRuntime() {
+        val rt = RuntimeVersion("iOS 11")
+
+        assertEquals("iOS", rt.name)
+        assertEquals(listOf("11"), rt.fragments)
+    }
+
+    @Test
+    fun shouldParseValidRuntimeWithFragments() {
+        val rt = RuntimeVersion("iOS 11.1")
+
+        assertEquals("iOS", rt.name)
+        assertEquals(listOf("11", "1"), rt.fragments)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun shouldThrowWhenRuntimeFormatIsInvalid() {
+        RuntimeVersion("iOS11")
+    }
+}


### PR DESCRIPTION
Add more information on no (alive) nodes to create a device and to device creation errors (when invalid runtime, model, etc. is specified).

> I also noticed that there is a potential bug in node selection when creating device forces new simulator to be created. This will only be a problem if someone has nonuniform nodes, i.e. nodes with different available simulator types. Added FIXME.