### PR TITLE
Fix running WDA for iOS 11 and iOS 12

### DIFF
--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/XcodeFinder.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/XcodeFinder.kt
@@ -1,0 +1,35 @@
+package com.badoo.automation.deviceserver
+
+import com.badoo.automation.deviceserver.host.IRemote
+import com.badoo.automation.deviceserver.host.management.Xcode
+import com.badoo.automation.deviceserver.host.management.XcodeVersion
+import java.io.File
+
+class XcodeFinder(private val remote: IRemote) {
+    /**
+     * Uses Spotlight to find installed versions of Xcode
+     * mdfind "kMDItemCFBundleIdentifier == 'com.apple.dt.Xcode'"
+     *
+     * @return List of installed Xcode applications
+     */
+    fun findInstalledXcodeApplications(): List<Xcode> {
+        val command = listOf("mdfind", "kMDItemCFBundleIdentifier == 'com.apple.dt.Xcode'")
+        val result = remote.exec(command, mapOf(), false, 30)
+        return result.stdOut
+            .lines()
+            .asSequence()
+            .filterNot { it.isBlank() }
+            .map { xcodePath ->
+                val developerDir = File(xcodePath.trim(), Xcode.CONTENTS_FOLDER)
+                val version = getXcodeVersion(developerDir)
+                Xcode(version = version, developerDir = developerDir)
+            }
+            .toList()
+    }
+
+    private fun getXcodeVersion(developerDir: File): XcodeVersion {
+        val environment = mapOf(Xcode.DEVELOPER_DIR to developerDir.absolutePath)
+        val xcodeBuildOut = remote.exec(listOf("xcodebuild", "-version"), environment, false, 30).stdOut
+        return XcodeVersion.fromXcodeBuildOutput(xcodeBuildOut)
+    }
+}

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/command/ChildProcess.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/command/ChildProcess.kt
@@ -9,6 +9,7 @@ import java.time.Duration
 
 class ChildProcess private constructor(
     command: List<String>,
+    environment: Map<String, String>,
     executor: IShellCommand,
     remoteHostname: String,
     private val processListener: LongRunningProcessListener
@@ -18,7 +19,7 @@ class ChildProcess private constructor(
 
     init {
         logger.debug(logMarker, "Starting long living process from command [$command]")
-        executor.startProcess(command, mapOf(), processListener = processListener)
+        executor.startProcess(command, environment, processListener = processListener)
         logger.debug(logMarker, "Started long living process $this from command [$command]")
     }
 
@@ -41,12 +42,16 @@ class ChildProcess private constructor(
 
     companion object {
         fun fromCommand(
-            remoteHost: String, userName: String, cmd: List<String>, isInteractiveShell: Boolean,
+            remoteHost: String,
+            userName: String,
+            cmd: List<String>,
+            environment: Map<String, String>,
+            isInteractiveShell: Boolean,
             out_reader: (line: String) -> Unit,
             err_reader: (line: String) -> Unit
         ): ChildProcess {
             val executor = Remote.getRemoteCommandExecutor(hostName = remoteHost, userName = userName, isInteractiveShell = isInteractiveShell)
-            return ChildProcess(cmd, executor, remoteHost, LongRunningProcessListener(out_reader, err_reader))
+            return ChildProcess(cmd, environment, executor, remoteHost, LongRunningProcessListener(out_reader, err_reader))
         }
     }
 }

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/command/RemoteShellCommand.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/command/RemoteShellCommand.kt
@@ -25,6 +25,7 @@ class RemoteShellCommand(
         val sshPrefix = arrayListOf<String>()
         sshPrefix.addAll(listOf(
                 SSH_COMMAND,
+                "-o", "SendEnv=DEVELOPER_DIR",
                 "-o", "ConnectTimeout=$connectionTimeout",
                 "-o", "PreferredAuthentications=publickey",
                 QUIET_MODE
@@ -59,7 +60,7 @@ class RemoteShellCommand(
                       processListener: IShellCommandListener): CommandResult {
         val cmd = getCommandWithSSHPrefix(command)
         val start = System.currentTimeMillis()
-        val result = super.exec(cmd, getEnvironmentForSSH(), timeOut, returnFailure, logMarker, processListener)
+        val result = super.exec(cmd, getEnvironmentForSSH(environment), timeOut, returnFailure, logMarker, processListener)
         val elapsed = System.currentTimeMillis() - start
         val marker = MapEntriesAppendingMarker(
             mapOf(
@@ -82,16 +83,16 @@ class RemoteShellCommand(
 
     override fun startProcess(command: List<String>, environment: Map<String, String>, logMarker: Marker?,
                               processListener: LongRunningProcessListener) {
-        super.startProcess(getCommandWithSSHPrefix(command), getEnvironmentForSSH(), logMarker, processListener)
+        super.startProcess(getCommandWithSSHPrefix(command), getEnvironmentForSSH(environment), logMarker, processListener)
     }
 
     override fun escape(value: String): String {
         return ShellUtils.escape(value)
     }
 
-    private fun getEnvironmentForSSH(): HashMap<String, String> {
+    private fun getEnvironmentForSSH(environment: Map<String, String>): HashMap<String, String> {
         val envWithSsh = HashMap<String, String>(sshEnv)
-        envWithSsh.putAll(envWithSsh)
+        envWithSsh.putAll(environment)
         return envWithSsh
     }
 

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/command/ShellCommand.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/command/ShellCommand.kt
@@ -68,7 +68,7 @@ open class ShellCommand(
     }
 
     private fun startProcessInternal(command: List<String>, environment: Map<String, String>, processListener: NuProcessHandler): NuProcess {
-        logger.info(logMarker, "Executing command: ${command.joinToString(" ")}")
+        logger.info(logMarker, "Executing command: [${command.joinToString(" ")}] with environment [$environment]")
         val cmdEnv = environment + commonEnvironment
         val processBuilder = builderFactory(command, cmdEnv)
         processBuilder.setProcessListener(processListener)

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/ISimulatorFactory.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/ISimulatorFactory.kt
@@ -3,6 +3,7 @@ package com.badoo.automation.deviceserver.host
 import com.badoo.automation.deviceserver.data.DeviceAllocatedPorts
 import com.badoo.automation.deviceserver.data.DeviceInfo
 import com.badoo.automation.deviceserver.data.DeviceRef
+import com.badoo.automation.deviceserver.host.management.Xcode
 import com.badoo.automation.deviceserver.ios.fbsimctl.FBSimctlDevice
 import com.badoo.automation.deviceserver.ios.simulator.ISimulator
 import com.badoo.automation.deviceserver.ios.simulator.Simulator
@@ -16,11 +17,12 @@ interface ISimulatorFactory {
             fbdev: FBSimctlDevice,
             ports: DeviceAllocatedPorts,
             deviceSetPath: String,
+            xcode: Xcode,
             wdaRunnerXctest: File,
             concurrentBoot: ThreadPoolDispatcher,
             headless: Boolean,
             fbsimctlSubject: String
     ): ISimulator {
-        return Simulator(ref, remote, DeviceInfo(fbdev), ports, deviceSetPath, wdaRunnerXctest, concurrentBoot, headless, fbsimctlSubject)
+        return Simulator(ref, remote, DeviceInfo(fbdev), ports, deviceSetPath, xcode, wdaRunnerXctest, concurrentBoot, headless, fbsimctlSubject)
     }
 }

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/management/Xcode.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/management/Xcode.kt
@@ -1,0 +1,10 @@
+package com.badoo.automation.deviceserver.host.management
+
+import java.io.File
+
+data class Xcode(val version: XcodeVersion, val developerDir: File) {
+    companion object {
+        const val DEVELOPER_DIR = "DEVELOPER_DIR"
+        const val CONTENTS_FOLDER = "Contents/Developer"
+    }
+}

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/device/DeviceFbsimctlProc.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/device/DeviceFbsimctlProc.kt
@@ -15,6 +15,7 @@ class DeviceFbsimctlProc(
         remoteHost: String,
         username: String,
         cmd: List<String>,
+        environment: Map<String, String>,
         isInteractiveShell: Boolean,
         out_reader: (line: String) -> Unit,
         err_reader: (line: String) -> Unit

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/device/UsbProxy.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/device/UsbProxy.kt
@@ -17,6 +17,7 @@ class UsbProxy(
         remoteHost: String,
         userName: String,
         cmd: List<String>,
+        environment: Map<String, String>,
         isInteractiveShell: Boolean,
         out_reader: (line: String) -> Unit,
         err_reader: (line: String) -> Unit
@@ -40,6 +41,7 @@ class UsbProxy(
             remote.hostName,
             remote.userName,
             listOf(IPROXY_BIN, localPort.toString(), devicePort.toString(), udid),
+            mapOf(),
             false,
             { message -> logger.debug(logMarker, "${this}: iproxy <o>: ${message.trim()}") },
             { message -> logger.debug(logMarker, "${this}: iproxy <e>: ${message.trim()}") }
@@ -49,6 +51,7 @@ class UsbProxy(
             remote.hostName,
             remote.userName,
             listOf(SOCAT_BIN, "tcp-listen:$localPort,reuseaddr,fork", "tcp:0.0.0.0:$localPort"),
+            mapOf(),
             false,
             { message -> logger.debug(logMarker, "${this}: socat <o>: ${message.trim()}") },
             { message -> logger.debug(logMarker, "${this}: socat <e>: ${message.trim()}") }

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/proc/FbsimctlProc.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/proc/FbsimctlProc.kt
@@ -16,6 +16,7 @@ open class FbsimctlProc(
         remoteHost: String,
         username: String,
         cmd: List<String>,
+        environment: Map<String, String>,
         isInteractiveShell: Boolean,
         out_reader: (line: String) -> Unit,
         err_reader: (line: String) -> Unit
@@ -33,6 +34,7 @@ open class FbsimctlProc(
                 remote.hostName,
                 remote.userName,
                 getFbsimctlCommand(headless),
+                mapOf(),
                 true,
                 { logger.info(logMarker, "${this@FbsimctlProc}: FbSimCtl <o>: ${it.trim()}") },
                 { logger.warn(logMarker, "${this@FbsimctlProc}: FbSimCtl <e>: ${it.trim()}") }

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/proc/SimulatorWebDriverAgent.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/proc/SimulatorWebDriverAgent.kt
@@ -2,6 +2,7 @@ package com.badoo.automation.deviceserver.ios.proc
 
 import com.badoo.automation.deviceserver.data.UDID
 import com.badoo.automation.deviceserver.host.IRemote
+import com.badoo.automation.deviceserver.host.management.Xcode
 import java.io.File
 import java.net.URI
 
@@ -9,6 +10,7 @@ class SimulatorWebDriverAgent(
         remote: IRemote,
         wdaRunnerXctest: File,
         udid: UDID,
+        xcode: Xcode,
         wdaEndpoint: URI
 ) : WebDriverAgent(
         remote = remote,
@@ -16,4 +18,6 @@ class SimulatorWebDriverAgent(
         hostApp = "com.apple.MobileAddressBook", // seems like AddressBook has the least memory usage and no alerts
         udid = udid,
         wdaEndpoint = wdaEndpoint
-)
+) {
+    override val environment = mapOf(Xcode.DEVELOPER_DIR to xcode.developerDir.absolutePath)
+}

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/proc/WebDriverAgent.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/proc/WebDriverAgent.kt
@@ -20,6 +20,7 @@ open class WebDriverAgent(
                 remoteHost: String,
                 userName: String,
                 cmd: List<String>,
+                environment: Map<String, String>,
                 isInteractiveShell: Boolean,
                 out_reader: (line: String) -> Unit,
                 err_reader: (line: String) -> Unit
@@ -37,6 +38,7 @@ open class WebDriverAgent(
             "listen"
     )
     private val uri: URI = uriWithPath(wdaEndpoint, "wda/healthcheck")
+    protected open val environment: Map<String, String> = mapOf()
 
     override fun toString(): String = "<$udid at ${remote.hostName}:${wdaEndpoint.port}>"
 
@@ -51,6 +53,7 @@ open class WebDriverAgent(
                 remote.hostName,
                 remote.userName,
                 launchXctestCommand,
+                environment,
                 false,
                 { message -> logger.info(logMarker, "${this@WebDriverAgent}: WDA <o>: ${message.trim()}") },
                 { message -> logger.warn(logMarker, "${this@WebDriverAgent}: WDA <e>: ${message.trim()}") }

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/simulator/Simulator.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/simulator/Simulator.kt
@@ -4,6 +4,7 @@ import com.badoo.automation.deviceserver.LogMarkers
 import com.badoo.automation.deviceserver.WaitTimeoutError
 import com.badoo.automation.deviceserver.data.*
 import com.badoo.automation.deviceserver.host.IRemote
+import com.badoo.automation.deviceserver.host.management.Xcode
 import com.badoo.automation.deviceserver.ios.fbsimctl.FBSimctlDeviceState
 import com.badoo.automation.deviceserver.ios.proc.FbsimctlProc
 import com.badoo.automation.deviceserver.ios.proc.SimulatorWebDriverAgent
@@ -35,6 +36,7 @@ class Simulator (
         deviceInfo: DeviceInfo,
         private val allocatedPorts: DeviceAllocatedPorts,
         private val deviceSetPath: String,
+        xcode: Xcode,
         wdaRunnerXctest: File,
         private val concurrentBootsPool: ThreadPoolDispatcher,
         headless: Boolean,
@@ -65,7 +67,7 @@ class Simulator (
 
     private lateinit var criticalAsyncPromise: Job // 1-1 from ruby
     private val fbsimctlProc: FbsimctlProc = FbsimctlProc(remote, deviceInfo.udid, fbsimctlEndpoint, headless)
-    private val wdaProc = SimulatorWebDriverAgent(remote, wdaRunnerXctest, deviceInfo.udid, wdaEndpoint)
+    private val wdaProc = SimulatorWebDriverAgent(remote, wdaRunnerXctest, deviceInfo.udid, xcode, wdaEndpoint)
     private val backup: ISimulatorBackup = SimulatorBackup(remote, udid, deviceSetPath)
     private val simulatorStatus = SimulatorStatus()
     private val logger = LoggerFactory.getLogger(javaClass.simpleName)

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/simulator/video/SimulatorVideoRecorder.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/simulator/video/SimulatorVideoRecorder.kt
@@ -15,8 +15,13 @@ import kotlin.concurrent.withLock
 class SimulatorVideoRecorder(
         private val udid: UDID,
         private val remote: IRemote,
-        private val childFactory: (remoteHost: String, username: String, cmd: List<String>, isInteractiveShell: Boolean,
-                                   out_reader: (line: String) -> Unit, err_reader: (line: String) -> Unit
+        private val childFactory: (remoteHost: String,
+                                   username: String,
+                                   cmd: List<String>,
+                                   environment: Map<String, String>,
+                                   isInteractiveShell: Boolean,
+                                   out_reader: (line: String) -> Unit,
+                                   err_reader: (line: String) -> Unit
         ) -> ChildProcess? = ChildProcess.Companion::fromCommand,
         private val recorderStopTimeout: Duration = RECORDER_STOP_TIMEOUT
 ) : LongRunningProc(udid, remote.hostName) {
@@ -69,7 +74,7 @@ class SimulatorVideoRecorder(
             }
 
             delete()
-            childProcess = childFactory(remote.hostName, remote.userName, listOf(startVideoRecordingCommand), false,
+            childProcess = childFactory(remote.hostName, remote.userName, listOf(startVideoRecordingCommand), mapOf(),false,
                 { logger.debug(logMarker, "$udid: VideoRecorder <o>: ${it.trim()}") },
                 { logger.debug(logMarker, "$udid: VideoRecorder <e>: ${it.trim()}") }
             )

--- a/device-server/src/test/kotlin/com/badoo/automation/deviceserver/XcodeFinderTest.kt
+++ b/device-server/src/test/kotlin/com/badoo/automation/deviceserver/XcodeFinderTest.kt
@@ -1,0 +1,47 @@
+package com.badoo.automation.deviceserver
+
+import com.badoo.automation.deviceserver.command.CommandResult
+import com.badoo.automation.deviceserver.host.IRemote
+import com.badoo.automation.deviceserver.host.management.Xcode
+import com.badoo.automation.deviceserver.host.management.XcodeVersion
+import com.nhaarman.mockito_kotlin.whenever
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+import kotlin.test.assertEquals
+
+internal class XcodeFinderTest {
+    @Before
+    fun setUp() {
+
+    }
+
+    @Test
+    fun testFindTwoXcodeApps() {
+        val mdfindResult = """
+            /Applications/Xcode-10.0.app
+            /Applications/Xcode-9.4.1.app
+        """.trimIndent()
+        val remote: IRemote = mockThis()
+
+        val mdfindCommandResult = CommandResult(stdOut = mdfindResult, stdErr = "", stdOutBytes = mdfindResult.toByteArray(), exitCode = 0)
+        whenever(remote.exec(listOf("mdfind", "kMDItemCFBundleIdentifier == 'com.apple.dt.Xcode'"), mapOf(), false, 30)).thenReturn(mdfindCommandResult)
+
+        val env9 = mapOf(Xcode.DEVELOPER_DIR to "/Applications/Xcode-9.4.1.app/Contents/Developer")
+        whenever(remote.exec(listOf("xcodebuild", "-version"), env9, false, 30))
+            .thenReturn(CommandResult(stdOut = "Xcode 9.4.1\nBuild version 9F2000\n", stdErr = "", stdOutBytes = mdfindResult.toByteArray(), exitCode = 0))
+
+        val env10 = mapOf(Xcode.DEVELOPER_DIR to "/Applications/Xcode-10.0.app/Contents/Developer")
+        whenever(remote.exec(listOf("xcodebuild", "-version"), env10, false, 30))
+            .thenReturn(CommandResult(stdOut = "Xcode 10.0\nBuild version 10A255\n", stdErr = "", stdOutBytes = mdfindResult.toByteArray(), exitCode = 0))
+
+        val actualXcodeApps = XcodeFinder(remote).findInstalledXcodeApplications()
+
+        val expected = listOf(
+            Xcode(XcodeVersion(10, 0), File("/Applications/Xcode-10.0.app/Contents/Developer")),
+            Xcode(XcodeVersion(9, 4), File("/Applications/Xcode-9.4.1.app/Contents/Developer"))
+        )
+
+        assertEquals(expected, actualXcodeApps)
+    }
+}

--- a/device-server/src/test/kotlin/com/badoo/automation/deviceserver/command/RemoteShellCommandTest.kt
+++ b/device-server/src/test/kotlin/com/badoo/automation/deviceserver/command/RemoteShellCommandTest.kt
@@ -53,6 +53,7 @@ class RemoteShellCommandTest {
 
         val expectedCommand = listOf(
                 "/usr/bin/ssh",
+                "-o", "SendEnv=DEVELOPER_DIR",
                 "-o", "ConnectTimeout=1",
                 "-o", "PreferredAuthentications=publickey",
                 "-q",
@@ -76,6 +77,7 @@ class RemoteShellCommandTest {
 
         val expectedCommand = listOf(
                 "/usr/bin/ssh",
+                "-o", "SendEnv=DEVELOPER_DIR",
                 "-o", "ConnectTimeout=1",
                 "-o", "PreferredAuthentications=publickey",
                 "-q",
@@ -98,6 +100,7 @@ class RemoteShellCommandTest {
 
         val expectedCommand = listOf(
                 "/usr/bin/ssh",
+                "-o", "SendEnv=DEVELOPER_DIR",
                 "-o", "ConnectTimeout=1",
                 "-o", "PreferredAuthentications=publickey",
                 "-q",

--- a/device-server/src/test/kotlin/com/badoo/automation/deviceserver/ios/proc/DeviceFbsimctlProcTest.kt
+++ b/device-server/src/test/kotlin/com/badoo/automation/deviceserver/ios/proc/DeviceFbsimctlProcTest.kt
@@ -55,6 +55,7 @@ class DeviceFbsimctlProcTest {
         remoteHost: String,
         username: String,
         cmd: List<String>,
+        environment: Map<String, String>,
         isInteractiveShell: Boolean,
         out_reader: (line: String) -> Unit,
         err_reader: (line: String) -> Unit

--- a/device-server/src/test/kotlin/com/badoo/automation/deviceserver/ios/proc/FbsimctlProcTest.kt
+++ b/device-server/src/test/kotlin/com/badoo/automation/deviceserver/ios/proc/FbsimctlProcTest.kt
@@ -65,6 +65,7 @@ class FbsimctlProcTest {
         remoteHost: String,
         username: String,
         cmd: List<String>,
+        environment: Map<String, String>,
         isInteractiveShell: Boolean,
         out_reader: (line: String) -> Unit,
         err_reader: (line: String) -> Unit

--- a/device-server/src/test/kotlin/com/badoo/automation/deviceserver/ios/simulator/video/SimulatorVideoRecorderTest.kt
+++ b/device-server/src/test/kotlin/com/badoo/automation/deviceserver/ios/simulator/video/SimulatorVideoRecorderTest.kt
@@ -19,7 +19,7 @@ class SimulatorVideoRecorderTest {
     private val udid = "udid"
     @Suppress("UNUSED_PARAMETER")
     private fun childFactory(
-        remoteHost: String, username: String, cmd: List<String>, isInteractiveShell: Boolean,
+        remoteHost: String, username: String, cmd: List<String>, env: Map<String, String>, isInteractiveShell: Boolean,
         out_reader: (line: String) -> Unit, err_reader: (line: String) -> Unit
     ): ChildProcess? {
         return childProcess


### PR DESCRIPTION
Allows to use two installed Xcode applications in order to allow WDA to use simulator runtimes for iOS 11 and iOS 12.
A workaround for issue https://github.com/facebook/WebDriverAgent/issues/992
which might not be resolved quickly.

This workaround will work if there are Xcode 9 and Xcode 10 installed.
When starting a Simulator Node, then XcodeFinder object will find installed Xcode applications and use appropriate Xcode version to start WebDriverAgent