### PR TITLE
Use WebDriverAgentRunner-Runner.app as host app for WebDriverAgent

### DIFF
--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/fbsimctl/FBSimctl.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/fbsimctl/FBSimctl.kt
@@ -6,6 +6,7 @@ import com.badoo.automation.deviceserver.command.RemoteShellCommand
 import com.badoo.automation.deviceserver.data.UDID
 import com.badoo.automation.deviceserver.util.ensure
 import org.slf4j.LoggerFactory
+import java.io.File
 import java.time.Duration
 
 class FBSimctl(
@@ -20,6 +21,14 @@ class FBSimctl(
     }
 
     private val logger = LoggerFactory.getLogger(javaClass.simpleName)
+
+    override fun installApp(udid: UDID, bundlePath: File) {
+        val response = fbsimctl(listOf("install", bundlePath.absolutePath), udid, raiseOnError = true)
+        val result = parser.parseInstallApp(response)
+        if (!result.isSuccess) {
+            throw FBSimctlError("Failed to install application [${bundlePath.absolutePath}]. Error:\n${result.errorMessage}")
+        }
+    }
 
     override fun listSimulators(): List<FBSimctlDevice> {
         val cmd = listOf("--simulators", "list")

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/fbsimctl/FBSimctlDTO.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/fbsimctl/FBSimctlDTO.kt
@@ -35,3 +35,8 @@ data class FBSimctlDeviceDiagnosticInfo(
         val coreSimulatorLogLocation: String?,
         val videoLocation: String?
 )
+
+data class FBSimctlInstallResult(
+        val isSuccess: Boolean,
+        val errorMessage: String = ""
+)

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/fbsimctl/IFBSimctl.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/fbsimctl/IFBSimctl.kt
@@ -1,8 +1,11 @@
 package com.badoo.automation.deviceserver.ios.fbsimctl
 
 import com.badoo.automation.deviceserver.data.UDID
+import java.io.File
 
 interface IFBSimctl {
+    fun installApp(udid: UDID, bundlePath: File)
+
     /**
      * List simulators
      */

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/fbsimctl/IFBSimctlResponseParser.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/fbsimctl/IFBSimctlResponseParser.kt
@@ -7,4 +7,5 @@ interface IFBSimctlResponseParser {
     fun parseDeviceCreation(response: String, isTransitional: Boolean): FBSimctlDevice
     fun parse(response: String): List<Map<String, Any>>
     fun parseDeviceSets(response: String): List<String>
+    fun parseInstallApp(response: String): FBSimctlInstallResult
 }


### PR DESCRIPTION
Using WebDriverAgentRunner-Runner.app as a host application for XCTest (WebDriverAgent) 
allows to use Xcode 10 with simulator runtimes for iOS 11 and iOS 12.

This is a workaround for issue facebook/WebDriverAgent#992 which might not be resolved quickly.

This fix is an alternative to the solution with two Xcode applications #15 