### PR TITLE
Terminate SafariViewService when cleaning cookies

### DIFF
--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/simulator/Simulator.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/simulator/Simulator.kt
@@ -76,6 +76,7 @@ class Simulator (
     )
     private val logMarker: Marker = MapEntriesAppendingMarker(commonLogMarkerDetails)
     private val fileSystem = FileSystem(remote, udid)
+    private val simulatorProcess = SimulatorProcess(remote, udid)
     //endregion
 
     //region properties from ruby with backing mutable field
@@ -540,6 +541,9 @@ class Simulator (
             throw IllegalStateException("$SAFARI_BUNDLE_ID not found in $apps for $this")
         }
 
+        // Have to kill Simulator's SafariViewService process as it holds cookies loaded
+        simulatorProcess.terminateChildProcess("SafariViewService")
+
         val cookieJarPaths = cookieJars.map { cookieJar ->
             File(safari.data_container, listOf("Library", "Cookies", cookieJar).joinToString(File.separator)).absolutePath
         }
@@ -548,6 +552,7 @@ class Simulator (
         cmd.addAll(cookieJarPaths)
         val result = remote.execIgnoringErrors(cmd)
         check(result.isSuccess) { "Failed to remove safari cookies ($cookieJarPaths on $remote for $this: $result" }
+
         return mapOf("status" to "true")
     }
 
@@ -611,7 +616,6 @@ class Simulator (
     }
 
     //endregion
-
     override fun uninstallApplication(bundleId: String) {
         remote.fbsimctl.uninstallApp(udid, bundleId)
     }

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/simulator/SimulatorProcess.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/simulator/SimulatorProcess.kt
@@ -1,0 +1,42 @@
+package com.badoo.automation.deviceserver.ios.simulator
+
+import com.badoo.automation.deviceserver.data.UDID
+import com.badoo.automation.deviceserver.host.IRemote
+
+class SimulatorProcess(
+    private val remote: IRemote,
+    private val udid: UDID
+) {
+    val mainProcessPid: Int
+        get() {
+            val command = listOf("/usr/bin/pgrep", "-fl", "launchd_sim")
+            val result = remote.execIgnoringErrors(command)
+
+            check(result.isSuccess) {
+                "No launchd_sim process is found for simulator with udid: $udid. " +
+                        "Found: stdout: [${result.stdOut}], stderr: [${result.stdErr}]."
+            }
+
+            val processList = result
+                .stdOut
+                .lines()
+                .filter { it.contains(udid) }
+
+            check(processList.isNotEmpty()) {
+                "No launchd_sim process is found for simulator with udid: $udid. " +
+                        "Found: stdout: [${result.stdOut}], stderr: [${result.stdErr}]."
+            }
+
+            return processList
+                .first()
+                .split(" ")
+                .first()
+                .toInt()
+        }
+
+    fun terminateChildProcess(processName: String) {
+        // Sends SIGKILL to process with parent pid $mainProcessPid and name $processName
+        val command = listOf("/usr/bin/pkill", "-9", "-P", "$mainProcessPid", "-f", processName)
+        remote.execIgnoringErrors(command)
+    }
+}

--- a/device-server/src/test/kotlin/com/badoo/automation/deviceserver/ios/simulator/SimulatorProcessTest.kt
+++ b/device-server/src/test/kotlin/com/badoo/automation/deviceserver/ios/simulator/SimulatorProcessTest.kt
@@ -1,0 +1,60 @@
+package com.badoo.automation.deviceserver.ios.simulator
+
+import com.badoo.automation.deviceserver.command.CommandResult
+import com.badoo.automation.deviceserver.data.UDID
+import com.badoo.automation.deviceserver.host.IRemote
+import com.badoo.automation.deviceserver.mockThis
+import com.nhaarman.mockito_kotlin.*
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import kotlin.test.assertFailsWith
+
+class SimulatorProcessTest {
+    private val udid: UDID = "ADB25768-5C9D-487E-A787-D271934B78B0"
+    private val remote = mockThis<IRemote>()
+    private val stdOutWithSimulatorPid = """
+        41757 launchd_sim /Users/z/Library/Developer/CoreSimulator/Devices/ADB25768-5C9D-487E-A787-D271934B78B0/data/var/run/launchd_bootstrap.plist
+        47009 /usr/bin/ssh -o ConnectTimeout=10 -o PreferredAuthentications=publickey -q -t -t z@localhost /usr/bin/pgrep -fl launchd_sim
+    """.trimIndent()
+
+    @Test
+    fun testSimulatorProcessFound() {
+        val simulatorProcess = SimulatorProcess(remote, udid)
+        val simulatorFoundCommandResult = CommandResult(stdOutWithSimulatorPid, "", ByteArray(0), 0)
+
+        whenever(remote.execIgnoringErrors(any(), any(), any()))
+            .thenReturn(simulatorFoundCommandResult)
+
+        assertEquals(41757, simulatorProcess.mainProcessPid)
+    }
+
+    @Test
+    fun testSimulatorProcessNotFound() {
+        val simulatorProcess = SimulatorProcess(remote, udid)
+        val noSimulatorFoundCommandResult = CommandResult("", "", ByteArray(0), 0)
+
+        whenever(remote.execIgnoringErrors(any(), any(), any()))
+            .thenReturn(noSimulatorFoundCommandResult)
+
+        assertFailsWith<IllegalStateException> {
+            simulatorProcess.mainProcessPid
+        }
+    }
+
+    @Test
+    fun testKillSimulatorProcess() {
+        val simulatorProcess = SimulatorProcess(remote, udid)
+
+        whenever(remote.execIgnoringErrors(any(), any(), any()))
+            .thenReturn(CommandResult(stdOutWithSimulatorPid, "", ByteArray(0), 0))
+            .thenReturn(CommandResult("", "", ByteArray(0), 0))
+
+        simulatorProcess.terminateChildProcess("SafariViewService")
+
+        val argumentCaptor = argumentCaptor<List<String>>()
+        verify(remote, times(2)).execIgnoringErrors(argumentCaptor.capture(), any(), any())
+
+        val pkillCommand = listOf("/usr/bin/pkill", "-9", "-P", "41757", "-f", "SafariViewService")
+        assertEquals(pkillCommand, argumentCaptor.secondValue)
+    }
+}


### PR DESCRIPTION
SafariViewService should be terminated in order to guarantee cookies are cleared for an application