### PR TITLE
 Running XCUI tests on simulators and devices, skip installing WDA 

### DIFF
--- a/client/rb/lib/ios-device-server-client/device_provider.rb
+++ b/client/rb/lib/ios-device-server-client/device_provider.rb
@@ -63,7 +63,7 @@ module IosDeviceServerClient
     def create(dc)
       with_http do |http|
         headers = { 'Content-Type' => 'application/json' }
- 
+
         if credentials
           headers['Authorization'] = auth_header_value
         end

--- a/client/rb/lib/ios-device-server-client/device_provider.rb
+++ b/client/rb/lib/ios-device-server-client/device_provider.rb
@@ -33,6 +33,7 @@ module IosDeviceServerClient
     end
   end
 
+  # @server in RemoteDevice
   class DeviceProvider
     attr_reader :credentials
 
@@ -62,7 +63,7 @@ module IosDeviceServerClient
     def create(dc)
       with_http do |http|
         headers = { 'Content-Type' => 'application/json' }
-
+ 
         if credentials
           headers['Authorization'] = auth_header_value
         end
@@ -170,6 +171,22 @@ module IosDeviceServerClient
         request = Net::HTTP::Delete.new('/devices/')
         request['Authorization'] = auth_header_value
         http.request(request)
+      end
+    end
+
+    def run_xcuitest(device_ref, test_execution_config)
+      raise_if_ref_is_empty(device_ref)
+
+      with_http do |http|
+        headers = { 'Content-Type' => 'application/json' }
+ 
+        if credentials
+          headers['Authorization'] = auth_header_value
+        end
+
+        request = Net::HTTP::Post.new("/devices/#{device_ref}/run_xcuitest", headers)
+        request.body = JSON.dump(test_execution_config)
+        return http.request(request)
       end
     end
 

--- a/client/rb/lib/ios-device-server-client/device_provider.rb
+++ b/client/rb/lib/ios-device-server-client/device_provider.rb
@@ -187,6 +187,22 @@ module IosDeviceServerClient
       end
     end
 
+    def set_env(device_ref, environment_variables)
+      raise_if_ref_is_empty(device_ref)
+
+      with_http do |http|
+        headers = { 'Content-Type' => 'application/json' }
+ 
+        if credentials
+          headers['Authorization'] = auth_header_value
+        end
+
+        request = Net::HTTP::Post.new("/devices/#{device_ref}/set_env", headers)
+        request.body = JSON.dump(environment_variables)
+        return http.request(request)
+      end
+    end
+
     def run_xcuitest(device_ref, test_execution_config)
       raise_if_ref_is_empty(device_ref)
 

--- a/client/rb/lib/ios-device-server-client/remote_device.rb
+++ b/client/rb/lib/ios-device-server-client/remote_device.rb
@@ -31,10 +31,10 @@ module IosDeviceServerClient
     # @return [String]
     attr_reader :device_ref
 
-    def initialize(server_endpoint, device_ref)
+    def initialize(server_endpoint, device_ref, read_timeout: 120)
       raise(ArgumentError, 'device_ref cannot be null') if device_ref.nil?
 
-      @server = DeviceProviderFactory.create(server_endpoint)
+      @server = DeviceProviderFactory.create(server_endpoint, read_timeout: read_timeout)
       @device_ref = device_ref
       @device = nil # fbsimctl client
       device = @server.get(@device_ref)
@@ -59,6 +59,12 @@ module IosDeviceServerClient
       @device = nil
       @server.reset(@device_ref)
       await(timeout: timeout)
+    end
+
+    def reset_async()
+      ensure_ready
+      @device = nil
+      @server.reset(@device_ref)
     end
 
     def await(timeout: 60)

--- a/client/rb/lib/ios-device-server-client/remote_device.rb
+++ b/client/rb/lib/ios-device-server-client/remote_device.rb
@@ -95,6 +95,11 @@ module IosDeviceServerClient
       @server.clear_safari_cookies(@device_ref)
     end
 
+    def set_env(environment_variables)
+      ensure_ready
+      return @server.set_env(@device_ref, environment_variables)
+    end
+
     def run_xcuitest(test_execution_config)
       ensure_ready
       return @server.run_xcuitest(@device_ref, test_execution_config)

--- a/client/rb/lib/ios-device-server-client/remote_device.rb
+++ b/client/rb/lib/ios-device-server-client/remote_device.rb
@@ -50,7 +50,6 @@ module IosDeviceServerClient
     end
 
     # region: device management
-
     def release
       @server.release(@device_ref)
     end
@@ -89,6 +88,10 @@ module IosDeviceServerClient
       @server.clear_safari_cookies(@device_ref)
     end
 
+    def run_xcuitest(test_execution_config)
+      ensure_ready
+      return @server.run_xcuitest(@device_ref, test_execution_config)
+    end
     # endregion
 
     # region: app management

--- a/device-server/scripts/build_fbsimctl.sh
+++ b/device-server/scripts/build_fbsimctl.sh
@@ -6,7 +6,7 @@ set -u
 # We are using forked version of fbsimctl with some fixes, see link below
 
 readonly REPOSITORY=https://github.com/facebook/FBSimulatorControl.git
-readonly REVISION=4330d48 # https://github.com/facebook/FBSimulatorControl/commits/master
+readonly REVISION=ec54965 # https://github.com/facebook/FBSimulatorControl/commits/master
 
 readonly VERSION_NAME=HEAD-${REVISION}
 readonly FBSIMCTL_BASE_PATH=/usr/local/Cellar/fbsimctl

--- a/device-server/scripts/build_fbsimctl.sh
+++ b/device-server/scripts/build_fbsimctl.sh
@@ -6,7 +6,7 @@ set -u
 # We are using forked version of fbsimctl with some fixes, see link below
 
 readonly REPOSITORY=https://github.com/facebook/FBSimulatorControl.git
-readonly REVISION=ec54965 # https://github.com/facebook/FBSimulatorControl/commits/master
+readonly REVISION=4330d48 # https://github.com/facebook/FBSimulatorControl/commits/master
 
 readonly VERSION_NAME=HEAD-${REVISION}
 readonly FBSIMCTL_BASE_PATH=/usr/local/Cellar/fbsimctl

--- a/device-server/scripts/update_wda.sh
+++ b/device-server/scripts/update_wda.sh
@@ -7,7 +7,7 @@ readonly SIGNING_PATCH=${SIGNING_PATCH:-}
 readonly NO_DEVICE_BUILD=${NO_DEVICE_BUILD:-0}
 
 readonly REPOSITORY=https://github.com/facebook/WebDriverAgent.git
-readonly REVISION=e92bce2
+readonly REVISION=bbd0009
 readonly DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 readonly WORKING_DIR=$(mktemp -d)
 readonly BASE_DEST=${DIR}/../../ios/facebook

--- a/device-server/scripts/update_wda.sh
+++ b/device-server/scripts/update_wda.sh
@@ -7,7 +7,7 @@ readonly SIGNING_PATCH=${SIGNING_PATCH:-}
 readonly NO_DEVICE_BUILD=${NO_DEVICE_BUILD:-0}
 
 readonly REPOSITORY=https://github.com/facebook/WebDriverAgent.git
-readonly REVISION=bbd0009
+readonly REVISION=e92bce2
 readonly DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 readonly WORKING_DIR=$(mktemp -d)
 readonly BASE_DEST=${DIR}/../../ios/facebook

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/DeviceServer.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/DeviceServer.kt
@@ -233,6 +233,11 @@ fun Application.module() {
                 get("state") {
                     call.respond(devicesController.getDeviceState(param(call, "ref")))
                 }
+                post("set_env") {
+                    val ref = param(call, "ref")
+                    val environmentVariables = jsonContent<Map<String, String>>(call)
+                    call.respond(devicesController.setEnvironmentVariables(ref, environmentVariables))
+                }
                 post("run_xcuitest") {
                     val ref = param(call, "ref")
                     val xcuiTestExecutionConfig = jsonContent<XcuiTestExecutionConfig>(call)

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/DeviceServer.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/DeviceServer.kt
@@ -233,6 +233,11 @@ fun Application.module() {
                 get("state") {
                     call.respond(devicesController.getDeviceState(param(call, "ref")))
                 }
+                post("run_xcuitest") {
+                    val ref = param(call, "ref")
+                    val xcuiTestExecutionConfig = jsonContent<XcuiTestExecutionConfig>(call)
+                    call.respond(devicesController.runXcuiTest(ref, xcuiTestExecutionConfig))
+                }
             }
         }
     }

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/NodeConfig.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/NodeConfig.kt
@@ -31,7 +31,10 @@ data class NodeConfig(
     val uninstallApps: Boolean = false,
 
     @JsonProperty("devices")
-    val knownDevices: List<KnownDevice> = emptyList()
+    val knownDevices: List<KnownDevice> = emptyList(),
+
+    @JsonProperty("environment_variables")
+    val environmentVariables: Map<String, String> = mapOf()
 ) {
 
     enum class NodeType {

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/command/RemoteShellCommand.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/command/RemoteShellCommand.kt
@@ -76,7 +76,6 @@ class RemoteShellCommand(
             logger.error(logMarker, message)
             throw SshConnectionException(message)
         }
-
         return result
     }
 
@@ -89,16 +88,13 @@ class RemoteShellCommand(
         return ShellUtils.escape(value)
     }
 
-    private fun getEnvironmentForSSH(): HashMap<String, String> {
-        val envWithSsh = HashMap<String, String>(sshEnv)
-        envWithSsh.putAll(envWithSsh)
-        return envWithSsh
+    private fun getEnvironmentForSSH(): Map<String, String> {
+        return HashMap(sshEnv)
     }
 
-    private fun getCommandWithSSHPrefix(command: List<String>): ArrayList<String> {
-        val commandWithSshPrefix = ArrayList<String>(sshCommandPrefix)
-        commandWithSshPrefix.addAll(command)
-        return commandWithSshPrefix
+    private fun getCommandWithSSHPrefix(command: List<String>): List<String> {
+        return ArrayList(sshCommandPrefix)
+                .plus(command)
     }
 
     private companion object {

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/controllers/DevicesController.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/controllers/DevicesController.kt
@@ -109,4 +109,8 @@ class DevicesController(private val deviceManager: IDeviceManager) {
         deviceManager.uninstallApplication(ref, bundleId)
         return happy
     }
+
+    fun runXcuiTest(ref: DeviceRef, xcuiTestExecutionConfig: XcuiTestExecutionConfig): Map<String, String> {
+        return deviceManager.runXcuiTest(ref, xcuiTestExecutionConfig)
+    }
 }

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/controllers/DevicesController.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/controllers/DevicesController.kt
@@ -122,6 +122,11 @@ class DevicesController(private val deviceManager: IDeviceManager) {
         return happy
     }
 
+    fun setEnvironmentVariables(ref: DeviceRef, environmentVariables: Map<String, String>): EmptyMap {
+        deviceManager.setEnvironmentVariables(ref, environmentVariables)
+        return happy
+    }
+
     fun runXcuiTest(ref: DeviceRef, xcuiTestExecutionConfig: XcuiTestExecutionConfig): Map<String, String> {
         return deviceManager.runXcuiTest(ref, xcuiTestExecutionConfig)
     }

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/data/DesiredCapabilities.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/data/DesiredCapabilities.kt
@@ -1,10 +1,15 @@
 package com.badoo.automation.deviceserver.data
 
+import com.fasterxml.jackson.annotation.JsonProperty
+
 data class DesiredCapabilities(
         val udid: String?,
         val model: String?,
         val os: String?,
         val headless: Boolean = true,
         val existing: Boolean = true,
-        val arch: String? = null
+        val arch: String? = null,
+
+        @JsonProperty("use_wda")
+        val useWda: Boolean = true
 )

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/data/XcuiTestExecutionConfig.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/data/XcuiTestExecutionConfig.kt
@@ -14,8 +14,5 @@ class XcuiTestExecutionConfig(
         val testName: String,
 
         @JsonProperty("path_to_dir_with_xctestrun_file")
-        val pathToDirWithXctestrunFile: Path,
-
-        @JsonProperty("environment_variables")
-        val environmentVariables: Map<String, String> = mapOf()
+        val pathToDirWithXctestrunFile: Path
 )

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/data/XcuiTestExecutionConfig.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/data/XcuiTestExecutionConfig.kt
@@ -1,0 +1,21 @@
+package com.badoo.automation.deviceserver.data
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import java.nio.file.Path
+
+class XcuiTestExecutionConfig(
+        @JsonProperty("app_name")
+        val appName: String,
+
+        @JsonProperty("xctestrun_file_name")
+        val xctestrunFileName: String,
+
+        @JsonProperty("test_name")
+        val testName: String,
+
+        @JsonProperty("path_to_dir_with_xctestrun_file")
+        val pathToDirWithXctestrunFile: Path,
+
+        @JsonProperty("environment_variables")
+        val environmentVariables: Map<String, String> = mapOf()
+)

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/data/XcuiTestExecutionConfig.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/data/XcuiTestExecutionConfig.kt
@@ -3,7 +3,7 @@ package com.badoo.automation.deviceserver.data
 import com.fasterxml.jackson.annotation.JsonProperty
 import java.nio.file.Path
 
-class XcuiTestExecutionConfig(
+data class XcuiTestExecutionConfig(
         @JsonProperty("app_name")
         val appName: String,
 

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/data/XcuiTestExecutionConfig.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/data/XcuiTestExecutionConfig.kt
@@ -14,5 +14,8 @@ data class XcuiTestExecutionConfig(
         val testName: String,
 
         @JsonProperty("path_to_dir_with_xctestrun_file")
-        val pathToDirWithXctestrunFile: Path
+        val pathToDirWithXctestrunFile: Path,
+
+        @JsonProperty("timeout_sec")
+        val timeoutSec: Long = 300
 )

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/DevicesNode.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/DevicesNode.kt
@@ -331,4 +331,12 @@ class DevicesNode(
         // single instance of server on node is implied, so we can kill all simulators and fbsimctl processes
         remote.execIgnoringErrors(listOf("pkill", "-9", "/usr/local/bin/fbsimctl"))
     }
+
+    override fun setEnvironmentVariables(deviceRef: DeviceRef, envs: Map<String, String>) {
+        throw(NotImplementedError("Setting environment variables is not supported by physical devices"))
+    }
+
+    override fun runXcuiTest(deviceRef: DeviceRef, xcuiTestExecutionConfig: XcuiTestExecutionConfig): Map<String, String> {
+        return slotByExternalRef(deviceRef).device.runXcuiTest(xcuiTestExecutionConfig)
+    }
 }

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/HostFactory.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/HostFactory.kt
@@ -43,7 +43,8 @@ class HostFactory(
                 ),
                 simulatorLimit = config.simulatorLimit,
                 concurrentBoots = config.concurrentBoots,
-                wdaRunnerXctest = getWdaRunnerXctest(remote.isLocalhost(), wdaSimulatorBundle, REMOTE_WDA_BUNDLE_ROOT)
+                wdaRunnerXctest = getWdaRunnerXctest(remote.isLocalhost(), wdaSimulatorBundle, REMOTE_WDA_BUNDLE_ROOT),
+                initialEnvironmentVariables = config.environmentVariables
             )
         } else {
             DevicesNode(

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/ISimulatorFactory.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/ISimulatorFactory.kt
@@ -19,8 +19,10 @@ interface ISimulatorFactory {
             wdaRunnerXctest: File,
             concurrentBoot: ThreadPoolDispatcher,
             headless: Boolean,
+            useWda: Boolean,
             fbsimctlSubject: String
     ): ISimulator {
-        return Simulator(ref, remote, DeviceInfo(fbdev), ports, deviceSetPath, wdaRunnerXctest, concurrentBoot, headless, fbsimctlSubject)
+        return Simulator(ref, remote, DeviceInfo(fbdev), ports, deviceSetPath, wdaRunnerXctest, concurrentBoot,
+                headless, useWda, fbsimctlSubject)
     }
 }

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/ISimulatorsNode.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/ISimulatorsNode.kt
@@ -37,4 +37,6 @@ interface ISimulatorsNode {
     fun createDeviceAsync(desiredCaps: DesiredCapabilities): DeviceDTO
     fun dispose()
     fun uninstallApplication(deviceRef: DeviceRef, bundleId: String)
+    fun setEnvironmentVariables(deviceRef: DeviceRef, envs: Map<String, String>)
+    fun runXcuiTest(deviceRef: DeviceRef, xcuiTestExecutionConfig: XcuiTestExecutionConfig) : Map<String, String>
 }

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/SimulatorsNode.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/SimulatorsNode.kt
@@ -250,7 +250,6 @@ class SimulatorsNode(
     }
 
     override fun runXcuiTest(deviceRef: DeviceRef, xcuiTestExecutionConfig: XcuiTestExecutionConfig) : Map<String, String> {
-        getDeviceFor(deviceRef).setEnvironmentVariables(xcuiTestExecutionConfig.environmentVariables)
         return getDeviceFor(deviceRef).runXcuiTest(xcuiTestExecutionConfig)
     }
 

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/management/DeviceManager.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/management/DeviceManager.kt
@@ -164,4 +164,12 @@ class DeviceManager(
     override fun pullFile(ref: DeviceRef, dataPath: DataPath): ByteArray {
         return nodeRegistry.activeDevices.getNodeFor(ref).pullFile(ref, dataPath)
     }
+
+    override fun setEnvironmentVariables(ref: DeviceRef, envs: Map<String, String>) {
+        nodeRegistry.activeDevices.getNodeFor(ref).setEnvironmentVariables(ref, envs)
+    }
+
+    override fun runXcuiTest(ref: DeviceRef, xcuiTestExecutionConfig: XcuiTestExecutionConfig): Map<String, String> {
+        return nodeRegistry.activeDevices.getNodeFor(ref).runXcuiTest(ref, xcuiTestExecutionConfig)
+    }
 }

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/management/IDeviceManager.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/management/IDeviceManager.kt
@@ -29,5 +29,7 @@ interface IDeviceManager {
     fun isReady(): Boolean
     fun listFiles(ref: DeviceRef, dataPath: DataPath): List<String>
     fun pullFile(ref: DeviceRef, dataPath: DataPath): ByteArray
-    fun uninstallApplication(ref: String, bundleId: String)
+    fun uninstallApplication(ref: DeviceRef, bundleId: String)
+    fun setEnvironmentVariables(ref: DeviceRef, envs: Map<String, String>)
+    fun runXcuiTest(ref: DeviceRef, xcuiTestExecutionConfig: XcuiTestExecutionConfig): Map<String, String>
 }

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/device/Device.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/device/Device.kt
@@ -370,11 +370,11 @@ class Device(
         logger.debug(logMarker, "Running XCUI test '${xcuiTestExecutionConfig.testName}' of '${xcuiTestExecutionConfig.appName}'" +
                 " using '${xcuiTestExecutionConfig.pathToDirWithXctestrunFile}/${xcuiTestExecutionConfig.xctestrunFileName}' on device $this")
 
-        val cmd = "xcodebuild test-without-building -xctestrun " +
-                "'${xcuiTestExecutionConfig.pathToDirWithXctestrunFile}/${xcuiTestExecutionConfig.xctestrunFileName}' " +
-                "-destination 'platform=iOS,id=$udid' -only-testing:${xcuiTestExecutionConfig.testName}"
+        val command = listOf("xcodebuild", "test-without-building", "-xctestrun",
+                "${xcuiTestExecutionConfig.pathToDirWithXctestrunFile}/${xcuiTestExecutionConfig.xctestrunFileName}",
+                "-destination", "platform=iOS,id=$udid", "-only-testing:${xcuiTestExecutionConfig.testName}")
 
-        val result = remote.shell(cmd)
+        val result = remote.execIgnoringErrors(command, timeOutSeconds = xcuiTestExecutionConfig.timeoutSec)
         return mapOf(
                 "command" to result.cmd.joinToString(" "),
                 "exitCode" to result.exitCode.toString(),

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/simulator/ISimulator.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/simulator/ISimulator.kt
@@ -19,6 +19,7 @@ interface ISimulator {
     val calabashPort: Int
     val videoRecorder: SimulatorVideoRecorder
     val fbsimctlSubject: String
+    val initialEnvironmentVariables: MutableMap<String, String>
 
     fun prepareAsync()
     fun resetAsync()
@@ -33,4 +34,6 @@ interface ISimulator {
     fun dataContainer(bundleId: String): DataContainer
     fun uninstallApplication(bundleId: String)
     fun deleteCrashLogs(): Boolean
+    fun setEnvironmentVariables(envs: Map<String, String>)
+    fun runXcuiTest(xcuiTestExecutionConfig: XcuiTestExecutionConfig): Map<String, String>
 }

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/simulator/Simulator.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/simulator/Simulator.kt
@@ -659,11 +659,11 @@ class Simulator (
         logger.debug(logMarker, "Running XCUI test '${xcuiTestExecutionConfig.testName}' of '${xcuiTestExecutionConfig.appName}'" +
                 " using '${xcuiTestExecutionConfig.pathToDirWithXctestrunFile}/${xcuiTestExecutionConfig.xctestrunFileName}' on Simulator $this")
 
-        val cmd = "xcodebuild test-without-building -xctestrun " +
-                "'${xcuiTestExecutionConfig.pathToDirWithXctestrunFile}/${xcuiTestExecutionConfig.xctestrunFileName}' " +
-                "-destination 'platform=iOS Simulator,id=$udid' -only-testing:${xcuiTestExecutionConfig.testName}"
+        val command = listOf("xcodebuild", "test-without-building", "-xctestrun",
+                "${xcuiTestExecutionConfig.pathToDirWithXctestrunFile}/${xcuiTestExecutionConfig.xctestrunFileName}",
+                "-destination", "platform=iOS Simulator,id=$udid", "-only-testing:${xcuiTestExecutionConfig.testName}")
 
-        val result = remote.shell(cmd)
+        val result = remote.execIgnoringErrors(command, timeOutSeconds = 300)
         return mapOf(
                 "command" to result.cmd.joinToString(" "),
                 "exitCode" to result.exitCode.toString(),

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/simulator/Simulator.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/simulator/Simulator.kt
@@ -29,7 +29,6 @@ import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 import kotlin.system.measureTimeMillis
 
-
 class Simulator (
         private val deviceRef: DeviceRef,
         private val remote: IRemote,
@@ -39,6 +38,7 @@ class Simulator (
         wdaRunnerXctest: File,
         private val concurrentBootsPool: ThreadPoolDispatcher,
         headless: Boolean,
+        private val useWda: Boolean,
         override val fbsimctlSubject: String
 ) : ISimulator
 {
@@ -79,6 +79,7 @@ class Simulator (
     private val logMarker: Marker = MapEntriesAppendingMarker(commonLogMarkerDetails)
     private val fileSystem = FileSystem(remote, udid)
     private val simulatorProcess = SimulatorProcess(remote, udid)
+    override val initialEnvironmentVariables = mutableMapOf<String, String>()
     //endregion
 
     //region properties from ruby with backing mutable field
@@ -119,7 +120,11 @@ class Simulator (
 
             logTiming("simulator boot") { boot() }
 
-            logTiming("starting WebDriverAgent") { startWdaWithRetry() }
+            if (useWda) {
+                logTiming("starting WebDriverAgent") { startWdaWithRetry() }
+            }
+
+            logTiming("setting environment variables") { setEnvironmentVariables(initialEnvironmentVariables) }
 
             logger.info(logMarker, "Finished preparing $this")
             deviceState = DeviceState.CREATED
@@ -179,7 +184,7 @@ class Simulator (
 
     private fun shutdown() {
         logger.info(logMarker, "Shutting down ${this@Simulator}")
-        ignoringErrors({ fbsimctlProc.kill() })
+        ignoringErrors { fbsimctlProc.kill() }
 
         if (remote.fbsimctl.listDevice(udid)?.state != FBSimctlDeviceState.SHUTDOWN.value) {
             remote.fbsimctl.shutdown(udid)
@@ -198,6 +203,7 @@ class Simulator (
             truncateSystemLogIfExists()
 
             logger.info(logMarker, "Starting fbsimctl on ${this@Simulator}")
+
             fbsimctlProc.start() // boots simulator
 
             var lastState: String? = null
@@ -412,7 +418,7 @@ class Simulator (
 
         runBlocking {
             val isFbsimctlHealthyTask = async { fbsimctlProc.isHealthy() }
-            val isWdaHealthyTask = async { wdaProc.isHealthy() }
+            val isWdaHealthyTask = async { if (useWda) wdaProc.isHealthy() else true }
 
             val isFbsimctlHealthy: Boolean = isFbsimctlHealthyTask.await()
             val isWdaHealthy: Boolean = isWdaHealthyTask.await()
@@ -640,5 +646,29 @@ class Simulator (
     override fun uninstallApplication(bundleId: String) {
         logger.debug(logMarker, "Uninstalling application $bundleId from Simulator $this")
         remote.execIgnoringErrors(listOf("xcrun", "simctl", "uninstall", udid, bundleId))
+    }
+
+    override fun setEnvironmentVariables(envs: Map<String, String>) {
+        logger.debug(logMarker, "Setting environment variables $envs for Simulator $this")
+        envs.keys.forEach {
+            remote.shell("xcrun simctl spawn $udid launchctl setenv $it ${envs[it]}")
+        }
+    }
+
+    override fun runXcuiTest(xcuiTestExecutionConfig: XcuiTestExecutionConfig): Map<String, String> {
+        logger.debug(logMarker, "Running XCUI test '${xcuiTestExecutionConfig.testName}' of '${xcuiTestExecutionConfig.appName}'" +
+                " using '${xcuiTestExecutionConfig.pathToDirWithXctestrunFile}/${xcuiTestExecutionConfig.xctestrunFileName}' on Simulator $this")
+
+        val cmd = "xcodebuild test-without-building -xctestrun " +
+                "'${xcuiTestExecutionConfig.pathToDirWithXctestrunFile}/${xcuiTestExecutionConfig.xctestrunFileName}' " +
+                "-destination 'platform=iOS Simulator,id=$udid' -only-testing:${xcuiTestExecutionConfig.testName}"
+
+        val result = remote.shell(cmd)
+        return mapOf(
+                "command" to result.cmd.joinToString(" "),
+                "exitCode" to result.exitCode.toString(),
+                "stdOut" to result.stdOut,
+                "stdErr" to result.stdErr
+        )
     }
 }

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/simulator/Simulator.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/simulator/Simulator.kt
@@ -659,7 +659,7 @@ class Simulator (
                 "${xcuiTestExecutionConfig.pathToDirWithXctestrunFile}/${xcuiTestExecutionConfig.xctestrunFileName}",
                 "-destination", "platform=iOS Simulator,id=$udid", "-only-testing:${xcuiTestExecutionConfig.testName}")
 
-        val result = remote.execIgnoringErrors(command, timeOutSeconds = 300)
+        val result = remote.execIgnoringErrors(command, timeOutSeconds = xcuiTestExecutionConfig.timeoutSec)
         return mapOf(
                 "command" to result.cmd.joinToString(" "),
                 "exitCode" to result.exitCode.toString(),

--- a/device-server/src/test/kotlin/com/badoo/automation/deviceserver/NodeConfigTest.kt
+++ b/device-server/src/test/kotlin/com/badoo/automation/deviceserver/NodeConfigTest.kt
@@ -18,7 +18,11 @@ class NodeConfigTest {
                 {
                     "udid": "c865bdbe652d17cbe2c79566fb046b73fed66a38"
                 }
-            ]
+            ],
+            "environment_variables": {
+                "ENV_NAME1": "ENV_VALUE1",
+                "ENV_NAME2": "ENV_VALUE2"
+            }
         }
     """
 
@@ -27,20 +31,20 @@ class NodeConfigTest {
         val config = JsonMapper().fromJson<NodeConfig>(config)
 
         val expected = NodeConfig(
-            type = NodeConfig.NodeType.Devices,
-            user = "user",
-            host = "host",
-            simulatorLimit = 1,
-            concurrentBoots = 1,
-            whitelistApps = setOf("bundle.id"),
-            uninstallApps = true,
-            knownDevices = listOf(
-                KnownDevice(
-                    "c865bdbe652d17cbe2c79566fb046b73fed66a38"
-                )
-            )
+                type = NodeConfig.NodeType.Devices,
+                user = "user",
+                host = "host",
+                simulatorLimit = 1,
+                concurrentBoots = 1,
+                whitelistApps = setOf("bundle.id"),
+                uninstallApps = true,
+                knownDevices = listOf(
+                        KnownDevice(
+                                "c865bdbe652d17cbe2c79566fb046b73fed66a38"
+                        )
+                ),
+                environmentVariables = mapOf("ENV_NAME1" to "ENV_VALUE1", "ENV_NAME2" to "ENV_VALUE2")
         )
-
         Assert.assertEquals(expected, config)
     }
 
@@ -49,16 +53,16 @@ class NodeConfigTest {
         val config = JsonMapper().fromJson<NodeConfig>("{}")
 
         val expected = NodeConfig(
-            type = NodeConfig.NodeType.Simulators,
-            user = "",
-            host = "localhost",
-            simulatorLimit = 6,
-            concurrentBoots = 3,
-            whitelistApps = emptySet(),
-            uninstallApps = false,
-            knownDevices = emptyList()
+                type = NodeConfig.NodeType.Simulators,
+                user = "",
+                host = "localhost",
+                simulatorLimit = 6,
+                concurrentBoots = 3,
+                whitelistApps = emptySet(),
+                uninstallApps = false,
+                knownDevices = emptyList(),
+                environmentVariables = mapOf()
         )
-
         Assert.assertEquals(expected, config)
     }
 }

--- a/device-server/src/test/kotlin/com/badoo/automation/deviceserver/controllers/DevicesControllerTest.kt
+++ b/device-server/src/test/kotlin/com/badoo/automation/deviceserver/controllers/DevicesControllerTest.kt
@@ -212,6 +212,18 @@ class DevicesControllerTest {
     }
 
     @Test
+    fun setEnvironmentVariables() {
+        val environmentVariables = mapOf(
+                "ENV_NAME1" to "ENV_VALUE1",
+                "ENV_NAME2" to "ENV_VALUE2"
+        )
+        val actualResult = deviceServer.setEnvironmentVariables(deviceRef, environmentVariables)
+
+        verify(deviceManager).setEnvironmentVariables(deviceRef, environmentVariables)
+        assertThat(actualResult, equalTo(happyEmpty))
+    }
+
+    @Test
     fun runXcuiTest() {
         val xcuiTestExecutionConfig = XcuiTestExecutionConfig(
                 "appName",

--- a/device-server/src/test/kotlin/com/badoo/automation/deviceserver/controllers/DevicesControllerTest.kt
+++ b/device-server/src/test/kotlin/com/badoo/automation/deviceserver/controllers/DevicesControllerTest.kt
@@ -13,6 +13,7 @@ import org.junit.Test
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import java.net.URL
+import java.nio.file.Paths
 
 private val happyEmpty: Map<Unit, Unit> = mapOf()
 
@@ -209,5 +210,24 @@ class DevicesControllerTest {
         val actualResult = deviceServer.getDeviceState(deviceRef)
         assertThat(actualResult, equalTo(expectedState))
     }
-}
 
+    @Test
+    fun runXcuiTest() {
+        val xcuiTestExecutionConfig = XcuiTestExecutionConfig(
+                "appName",
+                "file_name",
+                "test name",
+                Paths.get("/some/path")
+        )
+        val expectedResult = mapOf(
+                "command" to "some command",
+                "exitCode" to "0",
+                "stdOut" to "some stdOut",
+                "stdErr" to "some stdErr"
+        )
+        whenever(deviceManager.runXcuiTest(deviceRef, xcuiTestExecutionConfig)).thenReturn(expectedResult)
+        val actualResult = deviceServer.runXcuiTest(deviceRef, xcuiTestExecutionConfig)
+        verify(deviceManager).runXcuiTest(deviceRef, xcuiTestExecutionConfig)
+        assertThat(actualResult, equalTo(expectedResult))
+    }
+}

--- a/device-server/src/test/kotlin/com/badoo/automation/deviceserver/data/DesiredCapabilitiesTest.kt
+++ b/device-server/src/test/kotlin/com/badoo/automation/deviceserver/data/DesiredCapabilitiesTest.kt
@@ -60,4 +60,20 @@ class DesiredCapabilitiesTest {
 
         assertEquals(DesiredCapabilities(null, null, null, true, true), actual)
     }
+
+    @Test
+    fun fromJsonParsesUseWdaFalseCapability() {
+        val json = """{"use_wda": false}"""
+        val actual = fromJson(json)
+
+        assertEquals(DesiredCapabilities(null, null, null, true, true, useWda = false), actual)
+    }
+
+    @Test
+    fun fromJsonParsesUseWdaBoolAsTextCapability() {
+        val json = """{"use_wda": "false"}"""
+        val actual = fromJson(json)
+
+        assertEquals(DesiredCapabilities(null, null, null, true, useWda = false), actual)
+    }
 }

--- a/device-server/src/test/kotlin/com/badoo/automation/deviceserver/data/XcuiTestExecutionConfigTest.kt
+++ b/device-server/src/test/kotlin/com/badoo/automation/deviceserver/data/XcuiTestExecutionConfigTest.kt
@@ -1,0 +1,23 @@
+package com.badoo.automation.deviceserver.data
+
+import com.badoo.automation.deviceserver.JsonMapper
+import org.junit.Test
+import java.nio.file.Paths
+import kotlin.test.assertEquals
+
+class XcuiTestExecutionConfigTest {
+
+    private fun fromJson(json: String): XcuiTestExecutionConfig {
+        return JsonMapper().fromJson(json)
+    }
+
+    @Test
+    fun fromJsonParsesConfig() {
+        val json = """{"app_name": "com.app","xctestrun_file_name":"test.xctestrun",
+            |"test_name":"ui-tests/TestSome","path_to_dir_with_xctestrun_file":"/tmp/Build/Product"}""".trimMargin()
+        val actual = fromJson(json)
+
+        assertEquals(XcuiTestExecutionConfig("com.app", "test.xctestrun",
+                "ui-tests/TestSome", Paths.get("/tmp/Build/Product")), actual)
+    }
+}

--- a/device-server/src/test/kotlin/com/badoo/automation/deviceserver/data/XcuiTestExecutionConfigTest.kt
+++ b/device-server/src/test/kotlin/com/badoo/automation/deviceserver/data/XcuiTestExecutionConfigTest.kt
@@ -20,4 +20,24 @@ class XcuiTestExecutionConfigTest {
         assertEquals(XcuiTestExecutionConfig("com.app", "test.xctestrun",
                 "ui-tests/TestSome", Paths.get("/tmp/Build/Product")), actual)
     }
+
+    @Test
+    fun fromJsonParsesConfigWithTimeout() {
+        val json = """{"app_name": "com.app","xctestrun_file_name":"test.xctestrun", "timeout_sec": 240,
+            |"test_name":"ui-tests/TestSome","path_to_dir_with_xctestrun_file":"/tmp/Build/Product"}""".trimMargin()
+        val actual = fromJson(json)
+
+        assertEquals(XcuiTestExecutionConfig("com.app", "test.xctestrun",
+                "ui-tests/TestSome", Paths.get("/tmp/Build/Product"), 240), actual)
+    }
+
+    @Test
+    fun fromJsonParsesConfigWithTimeoutAsString() {
+        val json = """{"app_name": "com.app","xctestrun_file_name":"test.xctestrun", "timeout_sec": "240",
+            |"test_name":"ui-tests/TestSome","path_to_dir_with_xctestrun_file":"/tmp/Build/Product"}""".trimMargin()
+        val actual = fromJson(json)
+
+        assertEquals(XcuiTestExecutionConfig("com.app", "test.xctestrun",
+                "ui-tests/TestSome", Paths.get("/tmp/Build/Product"), 240), actual)
+    }
 }

--- a/device-server/src/test/kotlin/com/badoo/automation/deviceserver/host/SimulatorsNodeTest.kt
+++ b/device-server/src/test/kotlin/com/badoo/automation/deviceserver/host/SimulatorsNodeTest.kt
@@ -421,7 +421,6 @@ class SimulatorsNodeTest {
 
         val actualResult = simulatorsNode.runXcuiTest(ref1, xcuiTestExecutionConfig)
 
-        verify(simulatorMock).setEnvironmentVariables(xcuiTestExecutionConfig.environmentVariables)
         verify(simulatorMock).runXcuiTest(xcuiTestExecutionConfig)
         assertThat(actualResult, CoreMatchers.equalTo(expectedResult))
     }

--- a/device-server/src/test/kotlin/com/badoo/automation/deviceserver/host/management/DesiredCapabilitiesMatcherTest.kt
+++ b/device-server/src/test/kotlin/com/badoo/automation/deviceserver/host/management/DesiredCapabilitiesMatcherTest.kt
@@ -10,7 +10,7 @@ class DesiredCapabilitiesMatcherTest {
         val matcher = DesiredCapabilitiesMatcher()
 
         assertTrue {
-            matcher.isRuntimeMatch("iOS 11", "iOS 11.2")
+            matcher.isRuntimeMatch("iOS 11", "iOS 11")
         }
     }
 


### PR DESCRIPTION
Ability to run XCUI tests by `xcodebuild test-without-building...`, set environment variables by `xcrun simctl spawn $udid launchctl setenv ENV_NAME ENV_VALUE` and skip installing WebDriverAgent by setting desired capability `"use_wda": false`.
____
Endpoint `/devices/${ref}/run_xcuitest` takes following JSON (`timeout_sec` has default value 300):
```
{
    "app_name": "com.my.app",
    "xctestrun_file_name":"test.xctestrun",
    "test_name":"ui-tests/TestSome",
    "path_to_dir_with_xctestrun_file":"/tmp/Build/Product",
    "timeout_sec": 240
}
```
It returns a map with execution results (`command`, `exitCode`, `stdOut` and `stdErr`).
____
Endpoint `/devices/${ref}/set_env` takes following JSON:
```
{
    "ENV_NAME1": "ENV_VALUE1",
    "ENV_NAME2": "ENV_VALUE2",
    "ENV_NAME_": "ENV_VALUE_"
}
```
All specified environment variables will be set on selected simulator (setting envs is not supported by physical devices)

Also you can add node-specific environment variables to NodeConfig:
```
{
  "timeouts": {
    "device": 600
  },
  "nodes": [
    {
      "user": "",
      "host": "localhost",
      "simulator_limit": 6,
      "environment_variables": {
        "ENV_NAME1": "ENV_VALUE1",
        "ENV_NAME2": "ENV_VALUE2"
      }
    }
  ]
}
```
This environment variables will be set on booting or resetting of every simulator on _this node_.
___
For Ruby client added:
* `reset_async()` for RemoteDevice
* configurable HTTP read_timeout for DeviceProvider in RemoteDevice
* support of `set_env` and `run_xcuitest` commands