### PR TITLE
Allow setting and unsetting permissions individually.

### DIFF
--- a/client/rb/lib/ios-device-server-client/device_provider.rb
+++ b/client/rb/lib/ios-device-server-client/device_provider.rb
@@ -123,6 +123,19 @@ module IosDeviceServerClient
       end
     end
 
+    def set_permissions(device_ref, bundle_id:, permissions:)
+      raise_if_ref_is_empty(device_ref)
+
+      payload = {
+        bundle_id:   bundle_id,
+        permissions: permissions
+      }
+
+      with_http do |http|
+        http.post("/devices/#{device_ref}/permissions", JSON.dump(payload))
+      end
+    end
+
     def video_start(device_ref)
       raise_if_ref_is_empty(device_ref)
 

--- a/client/rb/lib/ios-device-server-client/permissions.rb
+++ b/client/rb/lib/ios-device-server-client/permissions.rb
@@ -1,0 +1,27 @@
+module IosDeviceServerClient
+  module Permissions
+    module Type
+      CALENDAR      = 'calendar'.freeze
+      CAMERA        = 'camera'.freeze
+      CONTACTS      = 'contacts'.freeze
+      HOME_KIT      = 'homekit'.freeze
+      MICROPHONE    = 'microphone'.freeze
+      PHOTOS        = 'photos'.freeze
+      REMINDERS     = 'reminders'.freeze
+      MEDIA_LIBRARY = 'medialibrary'.freeze
+      MOTION        = 'motion'.freeze
+      HEALTH        = 'health'.freeze
+      SIRI          = 'siri'.freeze
+      SPEECH        = 'speech'.freeze
+    end
+
+    module Allowed
+      YES    = 'yes'.freeze
+      NO     = 'no'.freeze
+      ALWAYS = 'always'.freeze
+      INUSE  = 'inuse'.freeze
+      NEVER  = 'never'.freeze
+      UNSET  = 'unset'.freeze
+    end
+  end
+end

--- a/client/rb/lib/ios-device-server-client/remote_device.rb
+++ b/client/rb/lib/ios-device-server-client/remote_device.rb
@@ -3,6 +3,7 @@ require 'base64'
 
 require_relative 'device_provider'
 require_relative 'device_client'
+require_relative 'permissions'
 
 module IosDeviceServerClient
   module RemoteDeviceError
@@ -95,6 +96,13 @@ module IosDeviceServerClient
     def approve_access(bundle_ids)
       ensure_ready
       @server.approve_access(@device_ref, bundle_ids)
+    end
+
+    # @param [String] bundle_id
+    # @param [Hash<String, String>] permissions map {Permissions::Type} to {Permissions::Allowed}
+    def set_permissions(bundle_id:, permissions:)
+      ensure_ready
+      @server.set_permissions(@device_ref, bundle_id: bundle_id, permissions: permissions)
     end
 
     def app_installed?(bundle_id)

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/DeviceServer.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/DeviceServer.kt
@@ -179,7 +179,7 @@ fun Application.module() {
                     call.respond(devicesController.deleteReleaseDevice(param(call, "ref")))
                 }
                 post("permissions") {
-                    call.respond(devicesController.setAccessToCameraAndThings(param(call, "ref"), jsonContent(call)))
+                    call.respond(devicesController.setPermissions(param(call, "ref"), jsonContent(call)))
                 }
                 get("endpoint/{port}") {
                     call.respond(devicesController.getEndpointFor(param(call, "ref"), paramInt(call, "port")))

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/JsonMapper.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/JsonMapper.kt
@@ -22,12 +22,17 @@ class JsonMapper {
         return mapper.readValue(stream, clazz)
     }
 
+    fun <T> fromJson(json: JsonNode, clazz: Class<T>): T {
+        return mapper.treeToValue(json, clazz)
+    }
+
     fun readTree(stream: InputStream): JsonNode {
         return mapper.readTree(stream) ?: throw RuntimeException("Failed to parse json")
     }
 
     inline fun <reified T> fromJson(string: String): T = fromJson(string, T::class.java)
     inline fun <reified T> fromJson(stream: InputStream): T = fromJson(stream, T::class.java)
+    inline fun <reified T> fromJson(json: JsonNode): T = fromJson(json, T::class.java)
 
     fun <T> toJson(value: T): String {
         return mapper.writeValueAsString(value)

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/controllers/DevicesController.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/controllers/DevicesController.kt
@@ -1,6 +1,7 @@
 package com.badoo.automation.deviceserver.controllers
 
 import com.badoo.automation.deviceserver.EmptyMap
+import com.badoo.automation.deviceserver.JsonMapper
 import com.badoo.automation.deviceserver.data.*
 import com.badoo.automation.deviceserver.host.management.IDeviceManager
 import com.fasterxml.jackson.databind.JsonNode
@@ -43,6 +44,17 @@ class DevicesController(private val deviceManager: IDeviceManager) {
 
     fun setAccessToCameraAndThings(ref: DeviceRef, jsonContent: JsonNode): EmptyMap {
         jsonContent.elements().forEach { deviceManager.approveAccess(ref, it["bundle_id"].textValue()) }
+        return happy
+    }
+
+    fun setPermissions(ref: DeviceRef, json: JsonNode): EmptyMap {
+        if (json.isArray) {
+            return setAccessToCameraAndThings(ref, json)
+        }
+
+        val permissions = JsonMapper().fromJson<AppPermissionsDto>(json)
+        deviceManager.setPermissions(ref, permissions)
+
         return happy
     }
 

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/data/AppPermissionsDto.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/data/AppPermissionsDto.kt
@@ -1,0 +1,11 @@
+package com.badoo.automation.deviceserver.data
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class AppPermissionsDto(
+    @JsonProperty("bundle_id")
+    val bundleId: String,
+
+    @JsonProperty("permissions")
+    val permissions: PermissionSet
+)

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/data/PermissionType.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/data/PermissionType.kt
@@ -1,0 +1,46 @@
+package com.badoo.automation.deviceserver.data
+
+import com.fasterxml.jackson.annotation.JsonValue
+
+enum class PermissionType(@JsonValue val value: String) {
+    Calendar("calendar"),
+
+    Camera("camera"),
+
+    Contacts("contacts"),
+
+    HomeKit("homekit"),
+
+    Microphone("microphone"),
+
+    Photos("photos"),
+
+    Reminders("reminders"),
+
+    MediaLibrary("medialibrary"),
+
+    Motion("motion"),
+
+    Health("health"),
+
+    Siri("siri"),
+
+    Speech("speech");
+}
+
+enum class PermissionAllowed(@JsonValue val value: String) {
+    Yes("yes"),
+
+    No("no"),
+
+    Always("always"),
+
+    Inuse("inuse"),
+
+    Never("never"),
+
+    Unset("unset");
+}
+
+class PermissionSet: HashMap<PermissionType, PermissionAllowed>()
+

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/DevicesNode.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/DevicesNode.kt
@@ -64,6 +64,10 @@ class DevicesNode(
         throw(NotImplementedError("Approve Access is not supported by physical devices"))
     }
 
+    override fun setPermissions(deviceRef: DeviceRef, appPermissions: AppPermissionsDto) {
+        throw(NotImplementedError("Set Permissions is not supported by physical devices"))
+    }
+
     override fun clearSafariCookies(deviceRef: DeviceRef) {
         throw(NotImplementedError("Clear Safari Cookies is not supported by physical devices"))
     }

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/ISimulatorsNode.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/ISimulatorsNode.kt
@@ -9,6 +9,7 @@ interface ISimulatorsNode {
     fun resetAsync(deviceRef: DeviceRef)
 
     fun approveAccess(deviceRef: DeviceRef, bundleId: String)
+    fun setPermissions(deviceRef: DeviceRef, appPermissions: AppPermissionsDto)
     fun clearSafariCookies(deviceRef: DeviceRef)
     fun shake(deviceRef: DeviceRef)
     fun endpointFor(deviceRef: DeviceRef, port: Int): URL

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/SimulatorsNode.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/SimulatorsNode.kt
@@ -123,6 +123,10 @@ class SimulatorsNode(
         getDeviceFor(deviceRef).approveAccess(bundleId)
     }
 
+    override fun setPermissions(deviceRef: DeviceRef, appPermissions: AppPermissionsDto) {
+        getDeviceFor(deviceRef).setPermissions(appPermissions.bundleId, appPermissions.permissions)
+    }
+
     override fun capacityRemaining(desiredCaps: DesiredCapabilities): Float {
         return (simulatorLimit - count()) * 1F / simulatorLimit
     }

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/management/DeviceManager.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/management/DeviceManager.kt
@@ -77,8 +77,12 @@ class DeviceManager(
         nodeRegistry.activeDevices.getNodeFor(ref).resetAsync(ref)
     }
 
-    override fun approveAccess(ref: DeviceRef, bundleId: String) {
+    override fun  approveAccess(ref: DeviceRef, bundleId: String) {
         nodeRegistry.activeDevices.getNodeFor(ref).approveAccess(ref, bundleId)
+    }
+
+    override fun setPermissions(ref: DeviceRef, permissions: AppPermissionsDto) {
+        nodeRegistry.activeDevices.getNodeFor(ref).setPermissions(ref, permissions)
     }
 
     override fun getEndpointFor(ref: DeviceRef, port: Int): URL {

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/management/IDeviceManager.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/management/IDeviceManager.kt
@@ -11,6 +11,7 @@ interface IDeviceManager {
     fun clearSafariCookies(ref: DeviceRef)
     fun resetAsyncDevice(ref: DeviceRef)
     fun approveAccess(ref: DeviceRef, bundleId: String)
+    fun setPermissions(ref: DeviceRef, permissions: AppPermissionsDto)
     fun getEndpointFor(ref: DeviceRef, port: Int): URL
     fun crashLogs(ref: DeviceRef, pastMinutes: Long?): List<CrashLog>
     fun deleteCrashLogs(ref: DeviceRef): Boolean

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/simulator/ISimulator.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/simulator/ISimulator.kt
@@ -25,6 +25,7 @@ interface ISimulator {
     fun status(): SimulatorStatusDTO
     fun endpointFor(port: Int): URL
     fun approveAccess(bundleId: String)
+    fun setPermissions(bundleId: String, permissions: PermissionSet)
     fun release(reason: String)
     fun clearSafariCookies(): Map<String, String>
     fun shake(): Boolean

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/simulator/Simulator.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/simulator/Simulator.kt
@@ -466,28 +466,24 @@ class Simulator (
     }
 
     //region approveAccess
+
     override fun approveAccess(bundleId: String) {
-        updatePermission(bundleId, "kTCCServiceCamera")
-        updatePermission(bundleId, "kTCCServiceMicrophone")
-        updatePermission(bundleId, "kTCCServicePhotos")
-        updatePermission(bundleId, "kTCCServiceAddressBook")
+        val permissions = SimulatorPermissions(remote, deviceSetPath, this)
+
+        permissions.setServicePermission(bundleId, PermissionType.Camera, PermissionAllowed.Yes)
+        permissions.setServicePermission(bundleId, PermissionType.Microphone, PermissionAllowed.Yes)
+        permissions.setServicePermission(bundleId, PermissionType.Photos, PermissionAllowed.Yes)
+        permissions.setServicePermission(bundleId, PermissionType.Contacts, PermissionAllowed.Yes)
     }
 
-    private fun updatePermission(bundleId: String, key: String) {
-        val path = File(deviceSetPath, udid)
-        val sqlCmd = "sqlite3 ${path.absolutePath}/data/Library/TCC/TCC.db"
-        val insert =
-            "$sqlCmd \"INSERT INTO access (service, client, client_type, allowed, prompt_count) VALUES ('$key','$bundleId',0,1,1);\""
-        val update = "$sqlCmd \"UPDATE access SET allowed=1 where client='$bundleId' AND service='$key'\""
+    override fun setPermissions(bundleId: String, permissions: PermissionSet) {
+        val manager = SimulatorPermissions(remote, deviceSetPath, this)
 
-        // FIXME: should we fail if sqlite3 fails (insert or update) or shall we do a separate check for access to be granted?
-        remote.shell(insert)
-        val result = remote.shell(update)
-
-        if (!result.isSuccess) {
-            logger.error(logMarker, "Device $this permission update failed ${result.stdErr}")
+        permissions.forEach { type, allowed ->
+            manager.setServicePermission(bundleId, type, allowed)
         }
     }
+
     //endregion
 
     //region release

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/simulator/SimulatorPermissions.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/simulator/SimulatorPermissions.kt
@@ -1,0 +1,59 @@
+package com.badoo.automation.deviceserver.ios.simulator
+
+import com.badoo.automation.deviceserver.data.PermissionAllowed
+import com.badoo.automation.deviceserver.data.PermissionType
+import com.badoo.automation.deviceserver.host.IRemote
+import java.io.File
+
+class SimulatorPermissions(
+    private val remote: IRemote,
+    private val deviceSetPath: String,
+    private val simulator: ISimulator
+) {
+
+    private val serviceKeys = mapOf(
+        PermissionType.Calendar to "kTCCServiceCalendar",
+        PermissionType.Camera to "kTCCServiceCamera",
+        PermissionType.Contacts to "kTCCServiceAddressBook",
+        PermissionType.HomeKit to "kTCCServiceWillow",
+        PermissionType.Microphone to "kTCCServiceMicrophone",
+        PermissionType.Photos to "kTCCServicePhotos",
+        PermissionType.Reminders to "kTCCServiceReminders",
+        PermissionType.MediaLibrary to "kTCCServiceMediaLibrary",
+        PermissionType.Motion to "kTCCServiceMotion",
+        PermissionType.Health to "kTCCServiceMSO",
+        PermissionType.Siri to "kTCCServiceSiri",
+        PermissionType.Speech to "kTCCServiceSpeechRecognition"
+    )
+
+    fun setServicePermission(bundleId: String, type: PermissionType, value: PermissionAllowed) {
+        val key = serviceKeys[type]
+                ?: throw(IllegalArgumentException("Permission $type is not a service type"))
+
+        val path = File(deviceSetPath, simulator.udid)
+        val sqlCmd = "sqlite3 ${path.absolutePath}/data/Library/TCC/TCC.db"
+
+        val delete = "$sqlCmd \"DELETE FROM access WHERE service = '$key' AND client = '$bundleId' AND client_type = 0;\""
+
+        if (!remote.shell(delete).isSuccess) {
+            throw(SimulatorError("Failed to unset type $type for $this "))
+        }
+
+        if (value == PermissionAllowed.Unset) {
+            return
+        }
+
+        val allowed = when (value) {
+            PermissionAllowed.Yes -> 1
+            PermissionAllowed.No -> 0
+            else -> throw(IllegalArgumentException("Unsupported value $value for type $type"))
+        }
+
+        val replace =
+            "$sqlCmd \"REPLACE INTO access (service, client, client_type, allowed, prompt_count) VALUES ('$key','$bundleId',0,$allowed,1);\""
+
+        if (!remote.shell(replace).isSuccess) {
+            throw(SimulatorError("Failed to update type $type for $this"))
+        }
+    }
+}


### PR DESCRIPTION
Change `/devices/${ref}/permissions` endpoint to allow setting and unsetting permissions individually.

Changed request format for the endpoint to take following JSON:
```
    {
        "bundle_id": "test.TestApp",
        "permissions": {
            "camera": "unset",
            "contacts": "no"
        }
    }
```

Allowed permission types are:
```
    calendar
    camera
    contacts
    homekit
    microphone
    photos
    reminders
    medialibrary
    motion
    health
    siri
    speech
```

Allowed permission values are:
```
    yes
    no
    unset
```

Old request format is deprecated but support was left for backwards compatibility:
```
    [{"bundle_id": "test.TestApp"}]
```
The old request will set camera, microphone, photos, contacts permissions for specified bundle ids.
Note that support for old request format will be deleted later.