### PR TITLE
Add locations permissions setting

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,6 @@
+[
+    "homebrew/Brewfile",
+    "homebrew/Brewfile.devices",
+].each do |f|
+    eval(File.new(f).read)
+end

--- a/client/rb/lib/ios-device-server-client/permissions.rb
+++ b/client/rb/lib/ios-device-server-client/permissions.rb
@@ -4,13 +4,14 @@ module IosDeviceServerClient
       CALENDAR      = 'calendar'.freeze
       CAMERA        = 'camera'.freeze
       CONTACTS      = 'contacts'.freeze
+      HEALTH        = 'health'.freeze
       HOME_KIT      = 'homekit'.freeze
+      LOCATION      = 'location'.freeze
+      MEDIA_LIBRARY = 'medialibrary'.freeze
       MICROPHONE    = 'microphone'.freeze
+      MOTION        = 'motion'.freeze
       PHOTOS        = 'photos'.freeze
       REMINDERS     = 'reminders'.freeze
-      MEDIA_LIBRARY = 'medialibrary'.freeze
-      MOTION        = 'motion'.freeze
-      HEALTH        = 'health'.freeze
       SIRI          = 'siri'.freeze
       SPEECH        = 'speech'.freeze
     end

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/data/PermissionType.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/data/PermissionType.kt
@@ -3,29 +3,37 @@ package com.badoo.automation.deviceserver.data
 import com.fasterxml.jackson.annotation.JsonValue
 
 enum class PermissionType(@JsonValue val value: String) {
+    // region yes/no/unset permissions
     Calendar("calendar"),
 
     Camera("camera"),
 
     Contacts("contacts"),
 
+    Health("health"),
+
     HomeKit("homekit"),
 
+    MediaLibrary("medialibrary"),
+
     Microphone("microphone"),
+
+    Motion("motion"),
+
+    Notifications("notifications"),
 
     Photos("photos"),
 
     Reminders("reminders"),
 
-    MediaLibrary("medialibrary"),
-
-    Motion("motion"),
-
-    Health("health"),
-
     Siri("siri"),
 
-    Speech("speech");
+    Speech("speech"),
+    // endregion
+
+    // region always/inuse/never/unset permissions
+    Location("location"),
+    // endregion
 }
 
 enum class PermissionAllowed(@JsonValue val value: String) {

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/simulator/Simulator.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/simulator/Simulator.kt
@@ -483,7 +483,7 @@ class Simulator (
         val manager = SimulatorPermissions(remote, deviceSetPath, this)
 
         permissions.forEach { type, allowed ->
-            manager.setServicePermission(bundleId, type, allowed)
+            manager.setPermission(bundleId, type, allowed)
         }
     }
 

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/simulator/SimulatorPermissions.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/simulator/SimulatorPermissions.kt
@@ -65,24 +65,13 @@ class SimulatorPermissions(
         }
     }
 
-
     private val appleSimUtils = "/usr/local/bin/applesimutils"
 
+    @Suppress("UNUSED_PARAMETER")
     private fun setNotificationsPermission(bundleId: String, allowed: PermissionAllowed) {
-        val value = when (allowed) {
-            PermissionAllowed.Yes -> "YES"
-            PermissionAllowed.No -> "NO"
-            PermissionAllowed.Unset -> "unset"
-            else -> throw IllegalArgumentException("Unsupported value $allowed for type ${PermissionType.Location}")
-        }
-
-        val cmd = listOf(appleSimUtils, "--byId", simulator.udid, "--bundle", bundleId, "--setPermissions", "notifications=$value")
-
-        val rv = remote.execIgnoringErrors(cmd)
-
-        if (!rv.isSuccess){
-            throw RuntimeException("Could not set notifications permission: $rv")
-        }
+        // Setting notifications permission is disallowed as it results in SpringBoard restart
+        // which breaks WebDriverAgent. Restarting SpringBoard and WebDriverAgent will take too much time.
+        throw RuntimeException("Setting notifications permission is not supported")
     }
 
     private fun setLocationPermission(bundleId: String, allowed: PermissionAllowed) {

--- a/device-server/src/test/kotlin/com/badoo/automation/deviceserver/data/PermissionSetTest.kt
+++ b/device-server/src/test/kotlin/com/badoo/automation/deviceserver/data/PermissionSetTest.kt
@@ -1,0 +1,31 @@
+package com.badoo.automation.deviceserver.data
+
+import com.badoo.automation.deviceserver.JsonMapper
+import org.junit.Assert.*
+import org.junit.Test
+
+class PermissionSetTest {
+    private fun fromJson(json: String): PermissionSet {
+        return JsonMapper().fromJson(json)
+    }
+
+    @Test
+    fun fromJsonParsesPermissionSet() {
+        val json = """
+            {
+                "location": "always",
+                "calendar": "yes",
+                "homekit": "unset"
+            }
+            """
+        val actual = fromJson(json)
+
+        val expected = PermissionSet()
+
+        expected[PermissionType.Calendar] = PermissionAllowed.Yes
+        expected[PermissionType.Location] = PermissionAllowed.Always
+        expected[PermissionType.HomeKit] = PermissionAllowed.Unset
+
+        assertEquals(expected, actual)
+    }
+}

--- a/homebrew/Brewfile
+++ b/homebrew/Brewfile
@@ -1,0 +1,16 @@
+tap "homebrew/bundle"
+tap "homebrew/core"
+
+tap "wix/brew"
+tap "facebook/fb"
+
+# Play, record, convert, and stream audio and video
+brew "ffmpeg"
+
+# Apple simulator utilities
+brew "wix/brew/applesimutils"
+
+# TODO: We need a custom formula/tap for fbsimctl as it has to be built from a fork
+# as we have to build it from https://github.com/badoo/FBSimulatorControl head
+# A Powerful Command Line for Managing iOS Simulators
+# brew "facebook/fb/fbsimctl", args: ["HEAD"]

--- a/homebrew/Brewfile.devices
+++ b/homebrew/Brewfile.devices
@@ -1,0 +1,14 @@
+tap "homebrew/bundle"
+tap "homebrew/core"
+
+# Both usbmuxd and libimobiledevice should be installed from the latest HEAD
+# but if they are already installed, brew will not auto-fetch new head
+
+# USB multiplexor daemon for iPhone and iPod Touch devices
+brew "usbmuxd", args: ["HEAD"]
+
+# Library to communicate with iOS devices natively
+brew "libimobiledevice", args: ["HEAD"]
+
+# netcat on steroids
+brew "socat"


### PR DESCRIPTION
Add ability to set location permissions.

We use wix/AppleSimulatorUtils (0.6.4 or higher) to set location permissions.

Probably we should update service permissions setter to use wix/AppleSimulatorUtils too, so we can delete and don't maintain sqlite TCC related code.

I removed the initially added ability to set notifications permissions as it requires SpringBoard restart which takes about 10 seconds and also breaks WebDriverAgent. So we will have to restart it too, adding even more time, making handling of alert manually faster and easier.
