### PR TITLE
Refactor fbsimctl failures filtering

### DIFF
--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/fbsimctl/FBSimctl.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/fbsimctl/FBSimctl.kt
@@ -17,7 +17,6 @@ class FBSimctl(
         private val SIMULATOR_SHUTDOWN_TIMEOUT: Duration = Duration.ofSeconds(60)
         const val FBSIMCTL_BIN = "/usr/local/bin/fbsimctl"
         const val RESPONSE_FORMAT = "--json"
-        private val NEW_LINE = System.lineSeparator()!!
     }
 
     private val logger = LoggerFactory.getLogger(javaClass.simpleName)
@@ -118,9 +117,13 @@ class FBSimctl(
         fbsimctl(listOf("uninstall", bundleId), udid, raiseOnError = true)
     }
 
-    private fun fbsimctl(cmd: String, udid: UDID? = null, jsonFormat: Boolean = true, timeOut: Duration = Duration.ofSeconds(30),
-                         raiseOnError: Boolean = true)
-            = fbsimctl(
+    private fun fbsimctl(
+        cmd: String,
+        udid: UDID? = null,
+        jsonFormat: Boolean = true,
+        timeOut: Duration = Duration.ofSeconds(30),
+        raiseOnError: Boolean = true
+    ) = fbsimctl(
         cmd.split(" "),
         udid,
         jsonFormat,
@@ -128,8 +131,13 @@ class FBSimctl(
         raiseOnError = raiseOnError
     )
 
-    private fun fbsimctl(cmd: List<String>, udid: UDID? = null, jsonFormat: Boolean = true, timeOut: Duration = Duration.ofSeconds(30),
-                         raiseOnError: Boolean = false): String {
+    private fun fbsimctl(
+        cmd: List<String>,
+        udid: UDID? = null,
+        jsonFormat: Boolean = true,
+        timeOut: Duration = Duration.ofSeconds(30),
+        raiseOnError: Boolean = false
+    ): String {
 
         val fbsimctlCommand = buildFbsimctlCommand(jsonFormat, udid, cmd)
 


### PR DESCRIPTION
We don't use fbsimctl failure splitting into warnings and errors any more. All failures were treated as errors by default.

- Removed fbsimctl warning/error splitting logic
- Added logging of all fbsimctl failures