### PR TITLE
Refactor setting of service permissions

### DIFF
--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/simulator/Simulator.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/simulator/Simulator.kt
@@ -497,18 +497,22 @@ class Simulator (
     override fun approveAccess(bundleId: String) {
         val permissions = SimulatorPermissions(remote, deviceSetPath, this)
 
-        permissions.setServicePermission(bundleId, PermissionType.Camera, PermissionAllowed.Yes)
-        permissions.setServicePermission(bundleId, PermissionType.Microphone, PermissionAllowed.Yes)
-        permissions.setServicePermission(bundleId, PermissionType.Photos, PermissionAllowed.Yes)
-        permissions.setServicePermission(bundleId, PermissionType.Contacts, PermissionAllowed.Yes)
+        val set = PermissionSet()
+
+        set.putAll(mapOf(
+            PermissionType.Camera to PermissionAllowed.Yes,
+            PermissionType.Microphone to PermissionAllowed.Yes,
+            PermissionType.Photos to PermissionAllowed.Yes,
+            PermissionType.Contacts to PermissionAllowed.Yes
+        ))
+
+        permissions.setPermissions(bundleId, set)
     }
 
     override fun setPermissions(bundleId: String, permissions: PermissionSet) {
         val manager = SimulatorPermissions(remote, deviceSetPath, this)
 
-        permissions.forEach { type, allowed ->
-            manager.setPermission(bundleId, type, allowed)
-        }
+        manager.setPermissions(bundleId, permissions)
     }
 
     //endregion


### PR DESCRIPTION
Reduce the number of SQLite process executions by batching all service permission changes from the permission set into a single SQLite call.

This significantly reduces response time for this operation, especially when a device server runs using SSH, making it basically constant.