### PR TITLE
Fix issue when WebDriverAgent gets deleted on remote host

### DIFF
--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ApplicationConfiguration.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ApplicationConfiguration.kt
@@ -16,4 +16,8 @@ class ApplicationConfiguration {
             ?: throw RuntimeException("Must set system property: -D$deviceServerConfigPathProperty=./config/.device_config")
 
     val fbsimctlVersion: String = System.getProperty("fbsimctl.version", "HEAD-d30c2a73")
+
+    val remoteWdaSimulatorBundleRoot = System.getProperty("remote.wda.simulator.bundle.path", "/usr/local/opt/web_driver_agent_simulator")
+
+    val remoteWdaDeviceBundleRoot = System.getProperty("remote.wda.device.bundle.path", "/usr/local/opt/web_driver_agent_device")
 }

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/DeviceServer.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/DeviceServer.kt
@@ -100,7 +100,9 @@ fun Application.module() {
     val config = serverConfig()
     val hostFactory = HostFactory(
         wdaSimulatorBundle = File(appConfiguration.wdaSimulatorBundlePath).canonicalFile,
+        remoteWdaSimulatorBundleRoot = File(appConfiguration.remoteWdaSimulatorBundleRoot).canonicalFile,
         wdaDeviceBundle = File(appConfiguration.wdaDeviceBundlePath).canonicalFile,
+        remoteWdaDeviceBundleRoot = File(appConfiguration.remoteWdaDeviceBundleRoot).canonicalFile,
         fbsimctlVersion = appConfiguration.fbsimctlVersion
     )
     val deviceManager = DeviceManager(config, hostFactory)

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/HostFactory.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/HostFactory.kt
@@ -9,13 +9,13 @@ import java.io.File
 class HostFactory(
     private val remoteProvider: (hostName: String, userName: String, publicHost: String) -> IRemote = { hostName, userName, publicHostName -> Remote(hostName, userName, publicHostName) },
     private val wdaSimulatorBundle: File,
+    private val remoteWdaSimulatorBundleRoot: File,
     private val wdaDeviceBundle: File,
+    private val remoteWdaDeviceBundleRoot: File,
     private val fbsimctlVersion: String
 ) : IHostFactory {
     companion object {
         val WDA_XCTEST = File("PlugIns/WebDriverAgentRunner.xctest")
-        private val REMOTE_WDA_BUNDLE_ROOT = File("/tmp/web_driver_agent/")
-        private val REMOTE_WDA_DEVICE_BUNDLE_ROOT = File("/tmp/web_driver_agent_devices/")
     }
 
     private val logger = LoggerFactory.getLogger(javaClass.simpleName)
@@ -39,13 +39,13 @@ class HostFactory(
                 hostChecker = SimulatorHostChecker(
                     remote,
                     wdaBundle = wdaSimulatorBundle,
-                    remoteWdaBundleRoot = REMOTE_WDA_BUNDLE_ROOT,
+                    remoteWdaBundleRoot = remoteWdaSimulatorBundleRoot,
                     fbsimctlVersion = fbsimctlVersion,
                     shutdownSimulators = config.shutdownSimulators
                 ),
                 simulatorLimit = config.simulatorLimit,
                 concurrentBoots = config.concurrentBoots,
-                wdaRunnerXctest = getWdaRunnerXctest(remote.isLocalhost(), wdaSimulatorBundle, REMOTE_WDA_BUNDLE_ROOT)
+                wdaRunnerXctest = getWdaRunnerXctest(remote.isLocalhost(), wdaSimulatorBundle, remoteWdaSimulatorBundleRoot)
             )
         } else {
             DevicesNode(
@@ -55,8 +55,8 @@ class HostFactory(
                 knownDevices = config.knownDevices,
                 uninstallApps = config.uninstallApps,
                 wdaBundlePath = wdaDeviceBundle,
-                remoteWdaBundleRoot = REMOTE_WDA_DEVICE_BUNDLE_ROOT,
-                wdaRunnerXctest = getWdaRunnerXctest(remote.isLocalhost(), wdaDeviceBundle, REMOTE_WDA_DEVICE_BUNDLE_ROOT),
+                remoteWdaBundleRoot = remoteWdaDeviceBundleRoot,
+                wdaRunnerXctest = getWdaRunnerXctest(remote.isLocalhost(), wdaDeviceBundle, remoteWdaDeviceBundleRoot),
                 fbsimctlVersion = fbsimctlVersion
             )
         }


### PR DESCRIPTION
Sometimes WebDriverAgent is deleted from /tmp on remote host.
 
Issue caused by MacOS periodically runs cleanup logic for /tmp folder.
So files for WebDriverAgent are deleted from /tmp periodically. 

On MacOS /tmp cleanup happens periodically deleting all files in /tmp that were not accessed during last 3 days by default.

```cat /etc/defaults/periodic.conf```

```
# 110.clean-tmps
daily_clean_tmps_enable="YES"				# Delete stuff daily
daily_clean_tmps_dirs="/tmp"				# Delete under here
daily_clean_tmps_days="3"				# If not accessed for
daily_clean_tmps_ignore=".X*-lock .X11-unix .ICE-unix .font-unix .XIM-unix"
daily_clean_tmps_ignore="$daily_clean_tmps_ignore quota.user quota.group"
```

