### PR TITLE
Add busy_timeout to handle TCC database being busy

### DIFF
--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/simulator/SimulatorPermissions.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/simulator/SimulatorPermissions.kt
@@ -49,7 +49,7 @@ class SimulatorPermissions(
         }
 
         val path = File(deviceSetPath, simulator.udid)
-        val sqlCmd = "sqlite3 ${path.absolutePath}/data/Library/TCC/TCC.db \"$sql\""
+        val sqlCmd = "sqlite3 ${path.absolutePath}/data/Library/TCC/TCC.db \"pragma busy_timeout=1000; $sql\""
 
         val result = remote.shell(sqlCmd)
 


### PR DESCRIPTION
Add busy_timeout pragma to reduce the likelihood of setting permissions command to faile with "Error: database is locked"