### PR TITLE
Add method to list media for iOS Simulator

### DIFF
--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/DeviceServer.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/DeviceServer.kt
@@ -236,6 +236,10 @@ fun Application.module() {
                     }
                 }
                 route("media") {
+                    get {
+                        val ref = param(call, "ref")
+                        call.respond(JsonMapper().toJson(MediaDto(devicesController.listMedia(ref))))
+                    }
                     delete {
                         val ref = param(call, "ref")
                         call.respond(devicesController.resetMedia(ref))

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/controllers/DevicesController.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/controllers/DevicesController.kt
@@ -109,6 +109,10 @@ class DevicesController(private val deviceManager: DeviceManager) {
         return happy
     }
 
+    fun listMedia(ref: DeviceRef): List<String> {
+        return deviceManager.listMedia(ref)
+    }
+
     fun resetMedia(ref: DeviceRef): EmptyMap {
         deviceManager.resetMedia(ref)
 

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/data/MediaDto.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/data/MediaDto.kt
@@ -1,0 +1,7 @@
+package com.badoo.automation.deviceserver.data
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+class MediaDto(
+    @JsonProperty("media")
+    val media: List<String>)

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/DevicesNode.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/DevicesNode.kt
@@ -47,6 +47,10 @@ class DevicesNode(
         throw(NotImplementedError("Resetting media is not supported by physical devices"))
     }
 
+    override fun listMedia(deviceRef: DeviceRef) : List<String> {
+        throw(NotImplementedError("Listing media is not supported by physical devices"))
+    }
+
     override fun addMedia(deviceRef: DeviceRef, fileName: String, data: ByteArray) {
         throw(NotImplementedError("Adding media is not supported by physical devices"))
     }

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/ISimulatorsNode.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/ISimulatorsNode.kt
@@ -30,6 +30,7 @@ interface ISimulatorsNode {
 
     fun addMedia(deviceRef: DeviceRef, fileName: String, data: ByteArray)
     fun resetMedia(deviceRef: DeviceRef)
+    fun listMedia(deviceRef: DeviceRef): List<String>
 
     fun getDiagnostic(deviceRef: DeviceRef, type: DiagnosticType, query: DiagnosticQuery): Diagnostic
     fun resetDiagnostic(deviceRef: DeviceRef, type: DiagnosticType)

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/SimulatorsNode.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/SimulatorsNode.kt
@@ -107,6 +107,10 @@ class SimulatorsNode(
         getDeviceFor(deviceRef).media.reset()
     }
 
+    override fun listMedia(deviceRef: DeviceRef) : List<String> {
+        return getDeviceFor(deviceRef).media.list()
+    }
+
     override fun addMedia(deviceRef: DeviceRef, fileName: String, data: ByteArray) {
         getDeviceFor(deviceRef).media.addMedia(File(fileName), data)
     }

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/management/DeviceManager.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/management/DeviceManager.kt
@@ -190,6 +190,10 @@ class DeviceManager(
         nodeRegistry.activeDevices.getNodeFor(ref).resetMedia(ref)
     }
 
+    fun listMedia(ref: DeviceRef): List<String> {
+        return nodeRegistry.activeDevices.getNodeFor(ref).listMedia(ref)
+    }
+
     fun addMedia(ref: DeviceRef, fileName: String, data: ByteArray) {
         nodeRegistry.activeDevices.getNodeFor(ref).addMedia(ref, fileName, data)
     }

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/simulator/data/Media.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/simulator/data/Media.kt
@@ -1,5 +1,6 @@
 package com.badoo.automation.deviceserver.ios.simulator.data
 
+import com.badoo.automation.deviceserver.command.CommandResult
 import com.badoo.automation.deviceserver.data.UDID
 import com.badoo.automation.deviceserver.host.IRemote
 import com.badoo.automation.deviceserver.util.withDefers
@@ -26,6 +27,11 @@ class Media(
 
         // restart assetsd to prevent fbsimctl upload failing with Error Domain=NSCocoaErrorDomain Code=-1 \"(null)\"
         restartAssetsd()
+    }
+
+    fun list() : List<String> {
+        val listCmd = listOf("ls", "-1", "$mediaPath/DCIM/100APPLE")
+        return remote.execIgnoringErrors(listCmd).stdOut.trim().lines()
     }
 
     fun addMedia(file: File, data: ByteArray) {


### PR DESCRIPTION
Added a method to list the files in data/Media/DCIM/100APPLE which shows the number of media added by `xcrun simctl addmedia` command