### PR TITLE
Force pseudo-terminal allocation for commands executed over SSH

### DIFF
--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/command/ChildProcess.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/command/ChildProcess.kt
@@ -41,11 +41,11 @@ class ChildProcess private constructor(
 
     companion object {
         fun fromCommand(
-            remoteHost: String, userName: String, cmd: List<String>, isInteractiveShell: Boolean,
+            remoteHost: String, userName: String, cmd: List<String>,
             out_reader: ((line: String) -> Unit)?,
             err_reader: ((line: String) -> Unit)?
         ): ChildProcess {
-            val executor = Remote.getRemoteCommandExecutor(hostName = remoteHost, userName = userName, isInteractiveShell = isInteractiveShell)
+            val executor = Remote.getRemoteCommandExecutor(hostName = remoteHost, userName = userName)
             return ChildProcess(cmd, executor, remoteHost, LongRunningProcessListener(out_reader, err_reader))
         }
     }

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/command/RemoteShellCommand.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/command/RemoteShellCommand.kt
@@ -13,7 +13,6 @@ class RemoteShellCommand(
     userName: String,
     builderFactory: (cmd: List<String>, env: Map<String, String>) -> NuProcessBuilder = ::defaultNuProcessBuilder,
     commonEnvironment: Map<String, String> = mapOf(),
-    isInteractiveShell: Boolean = false,
     isVerboseMode: Boolean = false,
     connectionTimeout: Int = 10
 ) : ShellCommand(builderFactory, commonEnvironment) {
@@ -31,11 +30,7 @@ class RemoteShellCommand(
                 QUIET_MODE
         ))
 
-        if (isInteractiveShell) {
-            sshPrefix.addAll(FORCE_PSEUDO_TERMINAL_ALLOCATION)
-        } else {
-            sshPrefix.add(NO_PSEUDO_TERMINAL_ALLOCATION)
-        }
+        sshPrefix.addAll(FORCE_PSEUDO_TERMINAL_ALLOCATION)
 
         if (isVerboseMode) {
             sshPrefix.add("-vvv")
@@ -107,7 +102,6 @@ class RemoteShellCommand(
         const val SSH_COMMAND = "/usr/bin/ssh"
         const val QUIET_MODE = "-q"
         val FORCE_PSEUDO_TERMINAL_ALLOCATION = listOf("-t", "-t")
-        const val NO_PSEUDO_TERMINAL_ALLOCATION = "-T"
         const val SSH_AUTH_SOCK = "SSH_AUTH_SOCK"
         const val SSH_ERROR = 255
     }

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/Remote.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/Remote.kt
@@ -24,11 +24,11 @@ class Remote(
         const val SSH_AUTH_SOCK = "SSH_AUTH_SOCK"
         private const val INITIAL_BUFFER_SIZE = 10 * 1024 * 1024 //FIXME: looks arbitrary. taken as an average of video file sizes
 
-        fun getRemoteCommandExecutor(hostName: String, userName: String, isInteractiveShell: Boolean = false): IShellCommand {
+        fun getRemoteCommandExecutor(hostName: String, userName: String): IShellCommand {
             return if (isLocalhost(hostName, userName)) {
                 ShellCommand(commonEnvironment = mapOf("HOME" to System.getProperty("user.home")))
             } else {
-                RemoteShellCommand(hostName, userName, isInteractiveShell = isInteractiveShell)
+                RemoteShellCommand(hostName, userName)
             }
         }
     }
@@ -80,7 +80,7 @@ class Remote(
 
         val tempFile = File.createTempFile("remoteFile", ".bin")
         try {
-            scpFromRemoteHost(file.absolutePath, tempFile.absolutePath, Duration.ofMinutes(2));
+            scpFromRemoteHost(file.absolutePath, tempFile.absolutePath, Duration.ofMinutes(2))
             return tempFile.readBytes()
         } finally {
             tempFile.delete()

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/device/DeviceFbsimctlProc.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/device/DeviceFbsimctlProc.kt
@@ -15,7 +15,6 @@ class DeviceFbsimctlProc(
         remoteHost: String,
         username: String,
         cmd: List<String>,
-        isInteractiveShell: Boolean,
         out_reader: (line: String) -> Unit,
         err_reader: (line: String) -> Unit
     ) -> ChildProcess = ChildProcess.Companion::fromCommand

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/device/UsbProxy.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/device/UsbProxy.kt
@@ -17,7 +17,6 @@ class UsbProxy(
         remoteHost: String,
         userName: String,
         cmd: List<String>,
-        isInteractiveShell: Boolean,
         out_reader: (line: String) -> Unit,
         err_reader: (line: String) -> Unit
     ) -> ChildProcess = ChildProcess.Companion::fromCommand
@@ -40,7 +39,6 @@ class UsbProxy(
             remote.hostName,
             remote.userName,
             listOf(IPROXY_BIN, localPort.toString(), devicePort.toString(), udid),
-            false,
             { message -> logger.trace(logMarker, "${this}: iproxy <o>: ${message.trim()}") },
             { message -> logger.debug(logMarker, "${this}: iproxy <e>: ${message.trim()}") }
         )
@@ -49,7 +47,6 @@ class UsbProxy(
             remote.hostName,
             remote.userName,
             listOf(SOCAT_BIN, "tcp-listen:$localPort,reuseaddr,fork", "tcp:0.0.0.0:$localPort"),
-            false,
             { message -> logger.trace(logMarker, "${this}: socat <o>: ${message.trim()}") },
             { message -> logger.debug(logMarker, "${this}: socat <e>: ${message.trim()}") }
         )

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/proc/FbsimctlProc.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/proc/FbsimctlProc.kt
@@ -16,7 +16,6 @@ open class FbsimctlProc(
         remoteHost: String,
         username: String,
         cmd: List<String>,
-        isInteractiveShell: Boolean,
         out_reader: (line: String) -> Unit,
         err_reader: (line: String) -> Unit
     ) -> ChildProcess = ChildProcess.Companion::fromCommand
@@ -33,7 +32,6 @@ open class FbsimctlProc(
                 remote.hostName,
                 remote.userName,
                 getFbsimctlCommand(headless),
-                true,
                 { logger.trace(logMarker, "${this@FbsimctlProc}: FbSimCtl <o>: ${it.trim()}") },
                 { logger.debug(logMarker, "${this@FbsimctlProc}: FbSimCtl <e>: ${it.trim()}") }
         )

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/proc/WebDriverAgent.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/proc/WebDriverAgent.kt
@@ -20,7 +20,6 @@ open class WebDriverAgent(
                 remoteHost: String,
                 userName: String,
                 cmd: List<String>,
-                isInteractiveShell: Boolean,
                 out_reader: ((line: String) -> Unit)?,
                 err_reader: ((line: String) -> Unit)?
         ) -> ChildProcess = ChildProcess.Companion::fromCommand
@@ -51,7 +50,6 @@ open class WebDriverAgent(
                 remote.hostName,
                 remote.userName,
                 launchXctestCommand,
-                false,
                 null,
                 { message -> logger.debug(logMarker, "${this@WebDriverAgent}: WDA <e>: ${message.trim()}") }
         )

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/simulator/video/SimulatorVideoRecorder.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/simulator/video/SimulatorVideoRecorder.kt
@@ -15,7 +15,7 @@ import kotlin.concurrent.withLock
 class SimulatorVideoRecorder(
     private val deviceInfo: DeviceInfo,
     private val remote: IRemote,
-    private val childFactory: (remoteHost: String, username: String, cmd: List<String>, isInteractiveShell: Boolean,
+    private val childFactory: (remoteHost: String, username: String, cmd: List<String>,
                                    out_reader: (line: String) -> Unit, err_reader: (line: String) -> Unit
         ) -> ChildProcess? = ChildProcess.Companion::fromCommand,
     private val recorderStopTimeout: Duration = RECORDER_STOP_TIMEOUT,
@@ -68,7 +68,7 @@ class SimulatorVideoRecorder(
 
             val cmd = shell(videoRecordingCmd(fps = 5, frameWidth = frameWidth, frameHeight = frameHeight))
 
-            childProcess = childFactory(remote.hostName, remote.userName, cmd, true,
+            childProcess = childFactory(remote.hostName, remote.userName, cmd,
                 { logger.debug(logMarker, "$udid: VideoRecorder <o>: ${it.trim()}") },
                 { logger.debug(logMarker, "$udid: VideoRecorder <e>: ${it.trim()}") }
             )

--- a/device-server/src/test/kotlin/com/badoo/automation/deviceserver/command/RemoteShellCommandTest.kt
+++ b/device-server/src/test/kotlin/com/badoo/automation/deviceserver/command/RemoteShellCommandTest.kt
@@ -42,34 +42,11 @@ class RemoteShellCommandTest {
         System.setOut(testOut)
     }
 
-    @Test fun nonInteractiveSshCommand() {
-        remoteShell = RemoteShellCommand(
-                remoteHost = remoteHost,
-                userName = userName,
-                builderFactory = ::nuProcessBuilderForTesting,
-                connectionTimeout = 1
-        )
-        remoteShell.exec(listOf("fbsimctl"), timeOut = Duration.ofMillis(100))
-
-        val expectedCommand = listOf(
-                "/usr/bin/ssh",
-                "-o", "ConnectTimeout=1",
-                "-o", "PreferredAuthentications=publickey",
-                "-q",
-                "-T",
-                userAtHost,
-            "fbsimctl"
-        )
-
-        assertEquals(expectedCommand, spyProcessBuilder.command())
-    }
-
     @Test fun interactiveSshCommand() {
         remoteShell = RemoteShellCommand(
                 remoteHost = remoteHost,
                 userName = userName,
                 builderFactory = ::nuProcessBuilderForTesting,
-                isInteractiveShell = true,
                 connectionTimeout = 1
                 )
         remoteShell.exec(listOf("fbsimctl"), timeOut = Duration.ofMillis(100))
@@ -101,7 +78,8 @@ class RemoteShellCommandTest {
                 "-o", "ConnectTimeout=1",
                 "-o", "PreferredAuthentications=publickey",
                 "-q",
-                "-T",
+                "-t",
+                "-t",
                 userAtHost,
                 "fbsimctl",
                 "udid='UDID'",

--- a/device-server/src/test/kotlin/com/badoo/automation/deviceserver/ios/proc/DeviceFbsimctlProcTest.kt
+++ b/device-server/src/test/kotlin/com/badoo/automation/deviceserver/ios/proc/DeviceFbsimctlProcTest.kt
@@ -55,7 +55,6 @@ class DeviceFbsimctlProcTest {
         remoteHost: String,
         username: String,
         cmd: List<String>,
-        isInteractiveShell: Boolean,
         out_reader: (line: String) -> Unit,
         err_reader: (line: String) -> Unit
     ): ChildProcess {

--- a/device-server/src/test/kotlin/com/badoo/automation/deviceserver/ios/proc/FbsimctlProcTest.kt
+++ b/device-server/src/test/kotlin/com/badoo/automation/deviceserver/ios/proc/FbsimctlProcTest.kt
@@ -65,7 +65,6 @@ class FbsimctlProcTest {
         remoteHost: String,
         username: String,
         cmd: List<String>,
-        isInteractiveShell: Boolean,
         out_reader: (line: String) -> Unit,
         err_reader: (line: String) -> Unit
     ): ChildProcess {


### PR DESCRIPTION
Mitigates issue when killing a process locally does not terminate it remotely.