### PR TITLE
Cleanup zombie processes

### DIFF
--- a/device-server/build.gradle
+++ b/device-server/build.gradle
@@ -70,7 +70,7 @@ dependencies {
     //endregion
 
     //region process management dependencies
-    compile group: 'net.java.dev.jna', name: 'jna', version: "4.5.1"
+    compile group: 'net.java.dev.jna', name: 'jna', version: "5.5.0"
     compile group: 'com.zaxxer', name: 'nuprocess', version: "1.1.3"
     //region
 

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/DeviceServer.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/DeviceServer.kt
@@ -1,5 +1,6 @@
 package com.badoo.automation.deviceserver
 
+import com.badoo.automation.deviceserver.command.ZombieReaper
 import com.badoo.automation.deviceserver.controllers.DevicesController
 import com.badoo.automation.deviceserver.controllers.StatusController
 import com.badoo.automation.deviceserver.data.*
@@ -69,6 +70,7 @@ fun getAddresses(): List<String> {
 }
 
 private val appConfiguration = ApplicationConfiguration()
+private val zombieReaper = ZombieReaper()
 
 private fun serverConfig(): DeviceServerConfig {
     if (appConfiguration.deviceServerConfigPath.isEmpty()) {
@@ -106,6 +108,8 @@ fun Application.module() {
     val deviceManager = DeviceManager(config, hostFactory)
     deviceManager.startAutoRegisteringDevices()
     deviceManager.launchAutoReleaseLoop()
+
+    zombieReaper.launchReapingZombies()
 
     val devicesController = DevicesController(deviceManager)
     val statusController = StatusController(deviceManager)

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/command/ZombieReaper.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/command/ZombieReaper.kt
@@ -1,0 +1,119 @@
+package com.badoo.automation.deviceserver.command
+
+import com.sun.jna.Library
+import com.sun.jna.Native
+import com.sun.jna.ptr.IntByReference
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.streams.toList
+
+class ZombieReaper {
+    private val logger: Logger = LoggerFactory.getLogger(javaClass.simpleName)
+    private val executor = Executors.newScheduledThreadPool(1)
+
+    fun launchReapingZombies() {
+        val task = {
+            // Try-catch is here in order to:
+            // - not to loose errors silently
+            // - not to interrupt subsequent executions
+            try {
+                reapZombies()
+            } catch (t: Throwable) {
+                logger.error("Failed to reap zombie processes. Reason: ${t.message}", t)
+            }
+        }
+
+        executor.scheduleWithFixedDelay(task, 60L, 60L, TimeUnit.SECONDS)
+    }
+
+    fun reapZombies() {
+        val zombies = findZombies()
+
+        zombies.forEach { zombie ->
+            reap(zombie)
+        }
+    }
+
+    private fun findZombies(): List<Int> {
+        val childProcesses = ProcessHandle.current().children()
+        val zombies = childProcesses.filter { it.isZombie }
+        return zombies.map { it.pid().toInt() }.toList()
+    }
+
+    private fun reap(pid: Int) {
+        val statusReference = IntByReference()
+        val waitResult = cLibrary.waitpid(pid, statusReference, WNOHANG)
+        val exitStatus = ProcessExitStatus(statusReference.value)
+
+        when (waitResult) {
+            pid -> logger.trace("Successfully reaped zombie process with PID $pid")
+            0 -> logger.trace("The zombie process with PID $pid has not yet changed it's state")
+            -1 -> logger.error("Error happened while reaping zombie process with PID $pid")
+        }
+
+        when {
+            exitStatus.isExited -> logger.trace("Zombie process with PID $pid had normal termination")
+            exitStatus.isSignaled -> logger.error("Zombie process with PID $pid was terminated by signal ${exitStatus.termSignal}")
+        }
+    }
+
+    private val ProcessHandle.isZombie: Boolean get() = !info().command().isPresent
+
+    companion object {
+        private val cLibrary: CLibrary = Native.load("c", CLibrary::class.java)
+        private const val WNOHANG = 1 /* Don't block waiting. */
+    }
+}
+
+/**
+ * Have to use C library to reap zombies
+ */
+private interface CLibrary : Library {
+    /**
+     * Wait for process to change state
+     * Refer to man page for waitpid
+     */
+    fun waitpid(pid: Int, statusReference: IntByReference, options: Int): Int
+}
+
+/**
+ * Exit status of a child process
+ * Refer to man page for waitpid
+ */
+private class ProcessExitStatus(private val status: Int) {
+    /**
+     * LibC macros WIFSIGNALED
+     *
+     * Nonzero if STATUS indicates termination by a signal.
+     *
+     * (((status) & 0x7f) + 1) >> 1) > 0)
+     */
+    val isSignaled: Boolean
+        get() {
+            return (((status and 0x7f) + 1) shl 1) > 0
+        }
+
+    /**
+     * LibC macros WIFEXITED
+     *
+     * True if STATUS indicates normal termination.
+     */
+    val isExited: Boolean
+        get() {
+            return termSignal == 0
+        }
+
+    /**
+     * LibC macros WTERMSIG
+     *
+     * If WIFSIGNALED(STATUS), the terminating signal.
+     *
+     * ((status) & 0x7f)
+     */
+    val termSignal: Int
+        get() {
+            return status and 0x7f
+        }
+}

--- a/device-server/src/test/kotlin/com/badoo/automation/deviceserver/command/ZombieReaperTest.kt
+++ b/device-server/src/test/kotlin/com/badoo/automation/deviceserver/command/ZombieReaperTest.kt
@@ -1,0 +1,98 @@
+package com.badoo.automation.deviceserver.command
+
+import com.sun.jna.Library
+import com.sun.jna.Native
+import org.junit.After
+import org.junit.Assert
+import org.junit.Test
+import kotlin.streams.toList
+
+class ZombieReaperTest {
+    private val reaper = ZombieReaper()
+
+    @After
+    fun tearDown() {
+        cleanupChildProcesses()
+        assertChildProcessCount(0)
+    }
+
+    @Test
+    fun testReapZombie() {
+        createZombie()
+        assertChildProcessCount(1)
+
+        reaper.reapZombies()
+
+        assertChildProcessCount(0)
+    }
+
+    @Test
+    fun testReapOnlyZombies() {
+        createZombie()
+        createRegularChildProcess()
+        assertChildProcessCount(2)
+
+        reaper.reapZombies()
+
+        assertChildProcessCount(1)
+    }
+
+    private fun assertChildProcessCount(expectedCount: Int) {
+        Assert.assertEquals(
+            "Wrong number of child processes",
+            expectedCount.toLong(),
+            ProcessHandle.current().children().count()
+        )
+    }
+
+    private fun cleanupChildProcesses() {
+        val pids = ProcessHandle.current().children().map { it.pid().toInt() }.toList()
+
+        pids.forEach { pid ->
+            testCLibrary.kill(pid, SIGKILL)
+        }
+
+        Thread.sleep(100L) // to ensure process has changed it's state
+
+        reaper.reapZombies()
+    }
+
+    private fun createRegularChildProcess(): Int {
+        val forkPID = testCLibrary.fork()
+
+        if (forkPID == 0) {
+            Thread.sleep(2000L) // ensure no actions are taken by a fork
+        }
+
+        return forkPID
+    }
+
+    private fun createZombie(): Int {
+        val forkPID = testCLibrary.fork()
+
+        if (forkPID == 0) {
+            Thread.sleep(2000L) // ensure no actions are taken by a fork
+        } else {
+            Thread.sleep(100L) // wait until initialized properly
+            killProcess(forkPID)
+        }
+
+        return forkPID
+    }
+
+    private fun killProcess(pid: Int) {
+        val signalResult = testCLibrary.kill(pid, SIGKILL)
+        Assert.assertEquals("Failed to send SIGKILL to process $pid", 0, signalResult)
+        Thread.sleep(50L) // to ensure process has changed it's state
+    }
+
+    companion object {
+        private const val SIGKILL = 9
+        private val testCLibrary: TestCLibrary = Native.load("c", TestCLibrary::class.java)
+    }
+}
+
+private interface TestCLibrary : Library {
+    fun kill(pid: Int, signal: Int): Int
+    fun fork(): Int
+}


### PR DESCRIPTION
Sometimes there are zombie processes left. 
It is almost impossible to create a zombie in Java,
but iOS Device Server manages to do so from time to time.

A periodic task would find zombies and call ```waitpid```.