### PR TITLE
Record video using WebDriverAgent's MJPEG streamer

### DIFF
--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ApplicationConfiguration.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ApplicationConfiguration.kt
@@ -1,5 +1,7 @@
 package com.badoo.automation.deviceserver
 
+import com.badoo.automation.deviceserver.ios.simulator.video.SimulatorVideoRecorder
+
 class ApplicationConfiguration {
     private val wdaSimulatorBundlePathProperty = "wda.bundle.path"
     val wdaSimulatorBundlePath: String = System.getProperty(wdaSimulatorBundlePathProperty)
@@ -23,4 +25,6 @@ class ApplicationConfiguration {
 
     val trustStorePath: String = System.getProperty("trust.store.path", "")
     val assetsPath: String = System.getProperty("media.assets.path", "")
+    val videoRecorderClassName = System.getProperty("video.recorder", SimulatorVideoRecorder::class.qualifiedName)
+    val videoRecorderFrameRate = Integer.getInteger("video.recorder.frame.rate", 4)
 }

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/data/DeviceAllocatedPorts.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/data/DeviceAllocatedPorts.kt
@@ -4,9 +4,10 @@ data class DeviceAllocatedPorts(
     val fbsimctlPort: Int,
     val wdaPort: Int,
     val calabashPort: Int,
+    val mjpegServerPort: Int,
     private val defaultCalabashPort: Int = 37265
 ) {
     fun toSet(): Set<Int> {
-        return setOf(fbsimctlPort, wdaPort, calabashPort, defaultCalabashPort)
+        return setOf(fbsimctlPort, wdaPort, calabashPort, mjpegServerPort, defaultCalabashPort)
     }
 }

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/data/DeviceDTO.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/data/DeviceDTO.kt
@@ -9,6 +9,7 @@ data class DeviceDTO(
         val fbsimctl_endpoint: URI,
         val wda_endpoint: URI,
         val calabash_port: Int,
+        val mjpeg_server_port: Int,
         val user_ports: Set<Int>, // From PortAllocator
         val info: DeviceInfo,
         val last_error: ErrorDto?,

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/DevicesNode.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/DevicesNode.kt
@@ -274,13 +274,21 @@ class DevicesNode(
         return false // crash logs are not supported on devices yet
     }
 
-    override fun videoRecordingDelete(deviceRef: DeviceRef): Unit = throw(NotImplementedError())
+    override fun videoRecordingDelete(deviceRef: DeviceRef) {
+        slotByExternalRef(deviceRef).device.videoRecorder.delete()
+    }
 
-    override fun videoRecordingGet(deviceRef: DeviceRef): ByteArray = throw(NotImplementedError())
+    override fun videoRecordingGet(deviceRef: DeviceRef): ByteArray {
+        return slotByExternalRef(deviceRef).device.videoRecorder.getRecording()
+    }
 
-    override fun videoRecordingStart(deviceRef: DeviceRef): Unit = throw(NotImplementedError())
+    override fun videoRecordingStart(deviceRef: DeviceRef) {
+        slotByExternalRef(deviceRef).device.videoRecorder.start()
+    }
 
-    override fun videoRecordingStop(deviceRef: DeviceRef): Unit = throw(NotImplementedError())
+    override fun videoRecordingStop(deviceRef: DeviceRef) {
+        slotByExternalRef(deviceRef).device.videoRecorder.stop()
+    }
 
     override fun listFiles(deviceRef: DeviceRef, dataPath: DataPath): List<String> = throw(NotImplementedError())
 
@@ -299,6 +307,7 @@ class DevicesNode(
             fbsimctl_endpoint = device.fbsimctlEndpoint,
             wda_endpoint = device.wdaEndpoint,
             calabash_port = device.calabashPort,
+            mjpeg_server_port = device.mjpegServerPort,
             user_ports = emptySet(),
             info = device.deviceInfo,
             last_error = device.lastException?.toDto(),

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/IRemote.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/IRemote.kt
@@ -1,6 +1,7 @@
 package com.badoo.automation.deviceserver.host
 
 import com.badoo.automation.deviceserver.command.CommandResult
+import com.badoo.automation.deviceserver.command.IShellCommand
 import com.badoo.automation.deviceserver.ios.fbsimctl.FBSimctl
 import java.io.File
 import java.time.Duration
@@ -21,6 +22,8 @@ interface IRemote {
     val hostName: String
     val userName: String
     val publicHostName: String
+    val localExecutor: IShellCommand
+    val remoteExecutor: IShellCommand
     fun isReachable(): Boolean
     fun isLocalhost(): Boolean = isLocalhost(hostName, userName)
 

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/Remote.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/Remote.kt
@@ -16,8 +16,8 @@ class Remote(
     override val hostName: String,
     override val userName: String,
     override val publicHostName: String,
-    private val localExecutor: IShellCommand = ShellCommand(commonEnvironment = mapOf("HOME" to System.getProperty("user.home"))),
-    private val remoteExecutor: IShellCommand = getRemoteCommandExecutor(hostName, userName),
+    override val localExecutor: IShellCommand = ShellCommand(commonEnvironment = mapOf("HOME" to System.getProperty("user.home"))),
+    override val remoteExecutor: IShellCommand = getRemoteCommandExecutor(hostName, userName),
     override val fbsimctl: FBSimctl = FBSimctl(remoteExecutor, FBSimctlResponseParser())
 ) : IRemote {
     companion object {

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/SimulatorsNode.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/SimulatorsNode.kt
@@ -144,6 +144,7 @@ class SimulatorsNode(
                 fbsimctlEndpoint,
                 wdaEndpoint,
                 calabashPort,
+                mjpegServerPort,
                 device.userPorts.toSet(),
                 device.info,
                 device.lastError?.toDto(),

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/management/PortAllocator.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/management/PortAllocator.kt
@@ -12,12 +12,12 @@ class PortAllocator(min: Int = PORT_RANGE_START, max: Int = PORT_RANGE_END) {
     private var ports: Set<Int> = IntRange(min, max).toSet()
 
     fun allocateDAP(): DeviceAllocatedPorts {
-        val take = allocate(3)
-        return DeviceAllocatedPorts(take[0], take[1], take[2])
+        val ports = allocate(4)
+        return DeviceAllocatedPorts(ports[0], ports[1], ports[2], ports[3])
     }
 
     fun deallocateDAP(dap: DeviceAllocatedPorts) {
-        deallocate(listOf(dap.calabashPort, dap.fbsimctlPort, dap.wdaPort))
+        deallocate(listOf(dap.calabashPort, dap.fbsimctlPort, dap.wdaPort, dap.mjpegServerPort))
     }
 
     fun available(): Int {

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/WdaClient.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/WdaClient.kt
@@ -113,4 +113,8 @@ class WdaClient(
             throw WdaException("WebDriver returned non zero status ${json["status"]}: ${json["value"]}")
         }
     }
+
+    fun updateAppiumSettings(settings: Map<Any, Any>): JsonNode {
+        return post("/session/$sessionId/appium/settings", settings)
+    }
 }

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/device/DeviceWebDriverAgent.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/device/DeviceWebDriverAgent.kt
@@ -12,6 +12,7 @@ class DeviceWebDriverAgent(
     udid: UDID,
     wdaEndpoint: URI,
     port: Int,
+    mjpegServerPort: Int,
     hostApp: String = wdaRunnerXctest.parentFile.parentFile.absolutePath
 ) : WebDriverAgent(
     remote = remote,
@@ -19,7 +20,8 @@ class DeviceWebDriverAgent(
     hostApp = hostApp,
     udid = udid,
     wdaEndpoint = wdaEndpoint,
-    port = port
+    port = port,
+    mjpegServerPort = mjpegServerPort
 ) {
     override fun terminateHostApp() {
         remote.fbsimctl.uninstallApp(udid, hostApp)

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/proc/SimulatorWebDriverAgent.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/proc/SimulatorWebDriverAgent.kt
@@ -11,13 +11,15 @@ class SimulatorWebDriverAgent(
         remote: IRemote,
         wdaRunnerXctest: File,
         udid: UDID,
-        wdaEndpoint: URI
+        wdaEndpoint: URI,
+        mjpegServerPort: Int
 ) : WebDriverAgent(
         remote = remote,
         wdaRunnerXctest = wdaRunnerXctest,
         hostApp = wdaRunnerXctest.parentFile.parentFile.absolutePath,
         udid = udid,
-        wdaEndpoint = wdaEndpoint
+        wdaEndpoint = wdaEndpoint,
+        mjpegServerPort = mjpegServerPort
 ) {
     override fun start() {
         installHostApp()

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/proc/WebDriverAgent.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/proc/WebDriverAgent.kt
@@ -16,6 +16,7 @@ open class WebDriverAgent(
     protected val udid: UDID,
     private val wdaEndpoint: URI,
     port: Int = wdaEndpoint.port,
+    mjpegServerPort: Int,
     private val childFactory: (
                 remoteHost: String,
                 userName: String,
@@ -33,6 +34,8 @@ open class WebDriverAgent(
             hostApp,
             "--port",
             port.toString(),
+            "--mjpeg-server-port",
+            mjpegServerPort.toString(),
             "--",
             "listen"
     )

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/simulator/ISimulator.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/simulator/ISimulator.kt
@@ -5,7 +5,7 @@ import com.badoo.automation.deviceserver.ios.simulator.data.DataContainer
 import com.badoo.automation.deviceserver.ios.simulator.data.Media
 import com.badoo.automation.deviceserver.ios.simulator.diagnostic.OsLog
 import com.badoo.automation.deviceserver.ios.simulator.diagnostic.SystemLog
-import com.badoo.automation.deviceserver.ios.simulator.video.SimulatorVideoRecorder
+import com.badoo.automation.deviceserver.ios.simulator.video.VideoRecorder
 import java.net.URI
 import java.net.URL
 
@@ -20,7 +20,8 @@ interface ISimulator {
     val info: DeviceInfo
     val lastError: Exception?
     val calabashPort: Int
-    val videoRecorder: SimulatorVideoRecorder
+    val mjpegServerPort: Int
+    val videoRecorder: VideoRecorder
     val fbsimctlSubject: String
     val systemLog: SystemLog
     val osLog: OsLog

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/simulator/video/MJPEGVideoRecorder.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/simulator/video/MJPEGVideoRecorder.kt
@@ -1,0 +1,178 @@
+package com.badoo.automation.deviceserver.ios.simulator.video
+
+import com.badoo.automation.deviceserver.LogMarkers
+import com.badoo.automation.deviceserver.data.DeviceInfo
+import com.badoo.automation.deviceserver.data.DeviceRef
+import com.badoo.automation.deviceserver.data.UDID
+import com.badoo.automation.deviceserver.host.IRemote
+import com.badoo.automation.deviceserver.ios.WdaClient
+import com.badoo.automation.deviceserver.util.CustomHttpClient
+import net.logstash.logback.marker.MapEntriesAppendingMarker
+import okhttp3.Call
+import okhttp3.Request
+import okhttp3.Response
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.io.File
+import java.net.URI
+import java.net.URL
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption.REPLACE_EXISTING
+import java.time.Duration
+import java.util.concurrent.Executors
+import java.util.concurrent.Future
+
+class MJPEGVideoRecorder(
+    private val deviceInfo: DeviceInfo,
+    private val remote: IRemote,
+    wdaEndpoint: URI,
+    mjpegServerPort: Int,
+    frameRate: Int,
+    private val ref: DeviceRef,
+    udid: UDID,
+    maxVideoDuration: Duration = Duration.ofMinutes(15),
+    private val videoFile: File = File.createTempFile("videoRecording_${deviceInfo.udid}_", ".mjpeg"),
+    private val encodedVideoFile: File = File.createTempFile("videoRecording_${deviceInfo.udid}_", ".mp4")
+) : VideoRecorder {
+    private val logger: Logger = LoggerFactory.getLogger(javaClass.simpleName)
+    private val logMarker = MapEntriesAppendingMarker(
+        mapOf(
+            LogMarkers.HOSTNAME to remote.publicHostName,
+            LogMarkers.UDID to udid,
+            LogMarkers.DEVICE_REF to ref
+        )
+    )
+    private val uniqueTag = "video-recording-$ref"
+    private val wdaClient = WdaClient(wdaEndpoint.toURL())
+    private val httpClient = CustomHttpClient().client.newBuilder().readTimeout(maxVideoDuration).build()
+    private val mjpegStreamUrl = URL("http://${remote.publicHostName}:${mjpegServerPort}")
+    private val mjpegSettings: Map<Any, Any> = mapOf(
+        "settings" to mapOf(
+            "mjpegServerFramerate" to frameRate,
+            "mjpegScalingFactor" to 50,
+            "mjpegServerScreenshotQuality" to 100
+        )
+    )
+    private val ffmpegCommand: List<String> = listOf(
+        "$FFMPEG_PATH",
+        "-hide_banner",
+        "-loglevel", "warning",
+        "-f", "mjpeg",
+        "-framerate", "$frameRate",
+        "-i", videoFile.absolutePath,
+        "-vf", "pad=ceil(iw/2)*2:ceil(ih/2)*2", // might use ffprobe to get resolution as well
+        "-an",
+        "-vcodec", "h264",
+        "-preset", "ultrafast",
+        "-tune", "fastdecode",
+        "-pix_fmt", "yuv420p",
+        "-metadata", "comment=$uniqueTag",
+        "-y",
+        encodedVideoFile.absolutePath
+    )
+    private var videoRecordingTask: Future<*>? = null
+    private var videoRecordingHttpCall: Call? = null
+
+    override fun toString(): String = "${javaClass.simpleName} for $ref"
+
+    override fun start() {
+        cleanupOldRecordings()
+        adjustVideoStreamSettings()
+        logger.debug(logMarker, "Starting video recording")
+
+        val request: Request = Request.Builder()
+            .get()
+            .url(mjpegStreamUrl)
+            .build()
+
+        val httpCall = httpClient.newCall(request)
+        val executor = Executors.newSingleThreadExecutor()
+        val recordingTask = executor.submit(recordStream(httpCall.execute()))
+        executor.shutdown()
+
+        videoRecordingTask = recordingTask
+        videoRecordingHttpCall = httpCall
+
+        logger.debug(logMarker, "Started video recording")
+    }
+
+    override fun stop() {
+        logger.debug(logMarker, "Stopping video recording")
+        stopVideoRecording()
+        logger.debug(logMarker, "Stopped video recording stopped")
+    }
+
+    override fun getRecording(): ByteArray {
+        logger.debug(logMarker, "Getting video recording")
+
+        return try {
+            if (FFMPEG_PATH == null) {
+                logger.error("Failed to find ffmpeg utility. Returning uncompressed video.")
+                videoFile.readBytes()
+            } else {
+                compressedVideo()
+            }
+        } finally {
+            delete()
+        }
+    }
+
+    override fun delete() {
+        logger.debug(logMarker, "Deleting video recording")
+        Files.deleteIfExists(videoFile.toPath())
+        Files.deleteIfExists(encodedVideoFile.toPath())
+    }
+
+    override fun dispose() {
+        logger.debug(logMarker, "Disposing video recording")
+        cleanupOldRecordings()
+        logger.debug(logMarker, "Disposed video recording")
+    }
+
+    private fun adjustVideoStreamSettings() {
+        wdaClient.attachToSession()
+        val response = wdaClient.updateAppiumSettings(mjpegSettings)
+        logger.trace(logMarker, "Updated MJPEG streaming server settings: $response")
+    }
+
+    private fun cleanupOldRecordings() {
+        stopVideoRecording()
+        delete()
+    }
+
+    private fun recordStream(response: Response): Runnable = Runnable {
+        response.use {
+            it.body?.let { responseBody ->
+                responseBody.byteStream().use { inputStream ->
+                    Files.copy(inputStream, videoFile.toPath(), REPLACE_EXISTING)
+                }
+            }
+        }
+    }
+
+    private fun compressedVideo(): ByteArray {
+        val result = remote.localExecutor.exec(ffmpegCommand, timeOut = Duration.ofSeconds(60L))
+
+        if (!result.isSuccess && (!encodedVideoFile.exists() || Files.size(encodedVideoFile.toPath()) == 0L)) {
+            val message = "Could not compress video file. Result stdErr: ${result.stdErr}"
+            logger.error(message)
+            throw SimulatorVideoRecordingException(message)
+        }
+
+        logger.debug(logMarker, "Successfully compressed video recording.")
+        return encodedVideoFile.readBytes()
+    }
+
+    private fun stopVideoRecording() {
+        videoRecordingHttpCall?.cancel()
+        videoRecordingHttpCall = null
+
+        videoRecordingTask?.cancel(true)
+        videoRecordingTask = null
+    }
+
+    private companion object {
+        private val ffmpegBinaries = listOf("/usr/local/bin/ffmpeg", "/usr/bin/ffmpeg")
+        val FFMPEG_PATH = ffmpegBinaries.find { File(it).canExecute() }
+    }
+}

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/simulator/video/VideoRecorder.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/simulator/video/VideoRecorder.kt
@@ -1,0 +1,9 @@
+package com.badoo.automation.deviceserver.ios.simulator.video
+
+interface VideoRecorder {
+    fun start()
+    fun stop()
+    fun getRecording(): ByteArray
+    fun delete()
+    fun dispose()
+}

--- a/device-server/src/test/kotlin/com/badoo/automation/deviceserver/TestUtil.kt
+++ b/device-server/src/test/kotlin/com/badoo/automation/deviceserver/TestUtil.kt
@@ -31,7 +31,7 @@ fun deviceDTOStub(ref: DeviceRef): DeviceDTO {
     ref, DeviceState.NONE,
     URI("http://fbsimctl/endpoint/for/testing"),
     URI("http://wda/endpoint/for/testing"),
-    0, setOf(0),
+    0, 1, setOf(0, 1),
     DeviceInfo("", "", "", "", ""),
     Exception().toDto(),
     capabilities = null)

--- a/device-server/src/test/kotlin/com/badoo/automation/deviceserver/host/SimulatorsNodeTest.kt
+++ b/device-server/src/test/kotlin/com/badoo/automation/deviceserver/host/SimulatorsNodeTest.kt
@@ -81,7 +81,8 @@ class SimulatorsNodeTest {
             URI("http://fbsimctl"),
             URI("http://wda"),
             4444,
-            setOf(1, 2, 3, 37265),
+            5555,
+            setOf(1, 2, 3, 4, 37265),
             DeviceInfo("", "", "", "", ""),
             null,
             ActualCapabilities(true, true, true)
@@ -119,7 +120,7 @@ class SimulatorsNodeTest {
                 eq("Udid1-rem-ote-node"),
                 eq(iRemote),
                 eq(fbsimulatorDevice),
-                eq(DeviceAllocatedPorts(1,2, 3)),
+                eq(DeviceAllocatedPorts(1, 2, 3, 4)),
                 eq("/node/specific/device/set"),
                 eq(File("some/file/from/wdaPathProc")),
                 any(),
@@ -165,10 +166,11 @@ class SimulatorsNodeTest {
             whenever(it.ref).thenReturn("someref$index")
             whenever(it.state).thenReturn(DeviceState.CREATING)
             whenever(it.info).thenReturn(DeviceInfo("","","","",""))
-            whenever(it.userPorts).thenReturn(DeviceAllocatedPorts(1,2,3))
+            whenever(it.userPorts).thenReturn(DeviceAllocatedPorts(1,2,3,4))
             whenever(it.fbsimctlEndpoint).thenReturn(URI("http://fbsimctl"))
             whenever(it.wdaEndpoint).thenReturn(URI("http://wda"))
             whenever(it.calabashPort).thenReturn(4444 + index)
+            whenever(it.mjpegServerPort).thenReturn(5555 + index)
             whenever(it.fbsimctlSubject).thenReturn("string representation of simulatorMock $index")
         }
     }
@@ -275,7 +277,8 @@ class SimulatorsNodeTest {
                 URI("http://fbsimctl"),
                 URI("http://wda"),
                 4444,
-                setOf(1,2,3, 37265),
+                5555,
+                setOf(1,2,3,4,37265),
                 DeviceInfo("", "", "", "", ""),
                 null,
                 ActualCapabilities(true, true, true)
@@ -310,13 +313,13 @@ class SimulatorsNodeTest {
     fun deleteReleaseReleasesExistingRef() {
         createTwoDevicesForTest()
         assertThat(simulatorsNode.count(), equalTo(2))
-        assertThat(portAllocator.available(), equalTo(4))
+        assertThat(portAllocator.available(), equalTo(2))
 
         val actual = simulatorsNode.deleteRelease(ref1, "test")
         assertThat(actual, equalTo(true))
         verify(simulatorMock).release(any())
         assertThat(simulatorsNode.count(), equalTo(1))
-        assertThat(portAllocator.available(), equalTo(7))
+        assertThat(portAllocator.available(), equalTo(6))
     }
 
     @Test


### PR DESCRIPTION
Using Appium's WebDriverAgent's MJPEG Streamer service.

1. Allows a bit more flexibility than Apple's via fbsimctl
2. Worked during transition to iOS 13 (Apple's was broken from Xcode 11 betas 5)
3. Allows record videos on real devices