### PR TITLE
Add API to get simulator's environment variable

### DIFF
--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/DeviceServer.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/DeviceServer.kt
@@ -375,6 +375,15 @@ fun Application.module() {
                     val environmentVariables = jsonContent<Map<String, String>>(call)
                     call.respond(devicesController.setEnvironmentVariables(ref, environmentVariables))
                 }
+                get("environment/{variableName}") {
+                    val ref = param(call, "ref")
+                    val variableName = param(call, "variableName")
+                    if (variableName.isNullOrEmpty()) {
+                        throw IllegalArgumentException("Environment variable name shouldn't be empty")
+                    } else {
+                        call.respond(devicesController.getEnvironmentVariable(ref, variableName))
+                    }
+                }
             }
         }
     }

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/controllers/DevicesController.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/controllers/DevicesController.kt
@@ -207,6 +207,10 @@ class DevicesController(private val deviceManager: DeviceManager) {
         return happy
     }
 
+    fun getEnvironmentVariable(ref: DeviceRef, variableName: String): String {
+        return deviceManager.getEnvironmentVariable(ref, variableName)
+    }
+
     fun deployApplication(appBundleDto: AppBundleDto): EmptyMap {
         deviceManager.deployApplication(appBundleDto)
         return happy

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/DevicesNode.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/DevicesNode.kt
@@ -495,6 +495,10 @@ class DevicesNode(
         throw(NotImplementedError("Setting environment variables is not supported by physical devices"))
     }
 
+    override fun getEnvironmentVariable(deviceRef: DeviceRef, variableName: String): String {
+        throw(NotImplementedError("Getting environment variables is not supported by physical devices"))
+    }
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/ISimulatorsNode.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/ISimulatorsNode.kt
@@ -57,6 +57,7 @@ interface ISimulatorsNode {
     fun uninstallApplication(deviceRef: DeviceRef, bundleId: String)
     fun deleteAppData(deviceRef: DeviceRef, bundleId: String)
     fun setEnvironmentVariables(deviceRef: DeviceRef, envs: Map<String, String>)
+    fun getEnvironmentVariable(deviceRef: DeviceRef, variableName: String): String
     fun pushFile(ref: DeviceRef, fileName: String, data: ByteArray, bundleId: String)
     fun installApplication(deviceRef: DeviceRef, appBundleDto: AppBundleDto)
     fun appInstallationStatus(deviceRef: DeviceRef): Map<String, Boolean>

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/SimulatorsNode.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/SimulatorsNode.kt
@@ -416,6 +416,10 @@ class SimulatorsNode(
         getDeviceFor(deviceRef).setEnvironmentVariables(envs)
     }
 
+    override fun getEnvironmentVariable(deviceRef: DeviceRef, variableName: String): String {
+        return getDeviceFor(deviceRef).getEnvironmentVariable(variableName)
+    }
+
     override fun toString(): String {
         return "${javaClass.simpleName} at $remoteAddress"
     }

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/management/DeviceManager.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/host/management/DeviceManager.kt
@@ -213,6 +213,10 @@ class DeviceManager(
         nodeRegistry.activeDevices.getNodeFor(ref).setEnvironmentVariables(ref, envs)
     }
 
+    fun getEnvironmentVariable(ref: DeviceRef, variableName: String): String {
+        return nodeRegistry.activeDevices.getNodeFor(ref).getEnvironmentVariable(ref, variableName)
+    }
+
     fun resetMedia(ref: DeviceRef) {
         nodeRegistry.activeDevices.getNodeFor(ref).resetMedia(ref)
     }

--- a/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/simulator/ISimulator.kt
+++ b/device-server/src/main/kotlin/com/badoo/automation/deviceserver/ios/simulator/ISimulator.kt
@@ -24,5 +24,6 @@ interface ISimulator: IDevice {
     fun dataContainer(bundleId: String): DataContainer
     fun deleteCrashLogs(): Boolean
     fun setEnvironmentVariables(envs: Map<String, String>)
+    fun getEnvironmentVariable(variableName: String): String
     fun applicationContainer(bundleId: String): DataContainer
 }

--- a/device-server/src/test/kotlin/com/badoo/automation/deviceserver/controllers/DevicesControllerTest.kt
+++ b/device-server/src/test/kotlin/com/badoo/automation/deviceserver/controllers/DevicesControllerTest.kt
@@ -198,4 +198,14 @@ class DevicesControllerTest {
         verify(deviceManager).setEnvironmentVariables(deviceRef, environmentVariables)
         assertThat(actualResult, equalTo(happyEmpty))
     }
+
+    @Test
+    fun getEnvironmentVariable() {
+        val environmentVariable = "ENV_NAME1"
+        val expectedValue = "ENV_VAL1"
+        whenever(deviceManager.getEnvironmentVariable(deviceRef, environmentVariable)).thenReturn(expectedValue)
+        val actualResult = deviceServer.getEnvironmentVariable(deviceRef, environmentVariable)
+
+        assertThat(actualResult, equalTo(expectedValue))
+    }
 }

--- a/device-server/src/test/kotlin/com/badoo/automation/deviceserver/host/SimulatorsNodeTest.kt
+++ b/device-server/src/test/kotlin/com/badoo/automation/deviceserver/host/SimulatorsNodeTest.kt
@@ -14,6 +14,7 @@ import com.nhaarman.mockito_kotlin.*
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.sameInstance
 import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Assert
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -376,5 +377,17 @@ class SimulatorsNodeTest {
         simulatorsNode.setEnvironmentVariables(ref1, mapOf())
 
         verify(simulatorMock).setEnvironmentVariables(mapOf())
+    }
+
+    @Test
+    fun getEnvironmentVariable() {
+        createDeviceForTest()
+        var variableName = "ENV_VAR1s"
+        var expectedValue = "ENV_VAR1s"
+
+        whenever(simulatorMock.getEnvironmentVariable(variableName)).thenReturn(expectedValue)
+        
+        val actual = simulatorsNode.getEnvironmentVariable(ref1, variableName)
+        Assert.assertThat(actual, equalTo(expectedValue))
     }
 }


### PR DESCRIPTION
Added API for retrieving simulator environment variable. 
Command:
`xcrun simctl getenv SIMULATOR_UDID ENVIRONMENT_VARIABLE`
 
API:
`/devices/{dev_ref}/environment/{env_variable}`

e.g:
```
curl http://localhost:4567/devices/AE9CF40B-AC20-4D08-A305-7F8CB483A3C0-localhost/environment/SIMULATOR_SHARED_RESOURCES_DIRECTORY
/Users/sravenmedarapu/Library/Developer/CoreSimulator/Devices/AE9CF40B-AC20-4D08-A305-7F8CB483A3C0/data
```